### PR TITLE
Add Resource Manangement Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Dev Dependencies
+
+The kafka and mysql containers from [salus-telemetry-bundle](https://github.com/racker/salus-telemetry-bundle#runningdeveloping-locally) must be running.
+
+[salus-telemetry-model](https://github.com/racker/salus-telemetry-model) must be recent and have been built to generate the `Resource_` sources under `target/classes/generated-sources/annotations/com.rackspace.salus.telemetry.model`.  If building the `-model` module via IntelliJ does not create this, you should try a `mvn clean` in that project before building.
+
+
+The `dev` profile should be set to ensure the properties from `application-dev.yml` get picked up.
+
+# Dev Testing
+
+To see events being posted to Kafka you can run this command:
+```
+docker exec -it telemetry-infra_kafka_1 \
+kafka-console-consumer --bootstrap-server localhost:9093 --topic telemetry.resources.json
+```
+
+You can trigger these events to be posted by utilizing some of the API operations below.
+
+# API Operations
+Examples of a subset of the available API operations.
+
+## Create a new resource
+```
+echo '{"resourceId": "host1", "presenceMonitoringEnabled": true}' | http POST 'localhost:8085/api/tenant/aaaaa/resources'
+```
+
+## Update an existing resource
+```
+echo '{"presenceMonitoringEnabled": false}' | http PUT 'localhost:8085/api/tenant/aaaaa/resources/host1'
+```
+
+## Get a stream of resources which have presence monitoring enabled
+```
+curl localhost:8085/api/envoys
+```
+
+> **Notes**:
+>
+> httpie will not receive the stream the same way curl does.  Currently unsure why.
+>
+> The name of this endpoint may change to be more specific to presence monitoring.
+
+## Delete a resource
+```
+http DELETE localhost:8085/api/tenant/aaaaa/resources/host1
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.1.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.rackspace.salus</groupId>
+  <artifactId>salus-telemetry-resource-management</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>salus-telemetry-resource-management</name>
+  <description>Service for handling Resource CRUD events</description>
+
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-devtools</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.7</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-protocol</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-protocol</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.3.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.3</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,12 @@
     <dependency>
       <groupId>uk.co.jemos.podam</groupId>
       <artifactId>podam</artifactId>
-      <version>LATEST</version>
+      <version>7.2.1.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,21 +20,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-      <scope>runtime</scope>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -61,12 +52,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.9.7</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
       <version>0.1.0-SNAPSHOT</version>
@@ -79,20 +64,20 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.rackspace.salus</groupId>
-      <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>5.3.7.Final</version>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.9.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <version>LATEST</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication
+@EnableJpaRepositories("com.rackspace.salus.telemetry")
+@EntityScan("com.rackspace.salus.telemetry")
+public class TelemetryResourceManagementApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TelemetryResourceManagementApplication.class, args);
+    }
+
+}
+

--- a/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.resource_management.services;
+package com.rackspace.salus.resource_management;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
-@EnableJpaRepositories("com.rackspace.salus.telemetry")
-@EntityScan("com.rackspace.salus.telemetry")
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
+@EntityScan("com.rackspace.salus.telemetry.model")
+@EnableScheduling
 public class TelemetryResourceManagementApplication {
 
     public static void main(String[] args) {
@@ -31,4 +34,3 @@ public class TelemetryResourceManagementApplication {
     }
 
 }
-

--- a/src/main/java/com/rackspace/salus/resource_management/config/AsyncConfig.java
+++ b/src/main/java/com/rackspace/salus/resource_management/config/AsyncConfig.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright 2019 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.resource_management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        return new ThreadPoolTaskExecutor();
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/config/ResourceManagementProperties.java
+++ b/src/main/java/com/rackspace/salus/resource_management/config/ResourceManagementProperties.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.resource_management.services.config;
+package com.rackspace.salus.resource_management.config;
 
-import com.rackspace.salus.resource_management.services.types.KafkaMessageType;
+import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/rackspace/salus/resource_management/config/ResourceManagementProperties.java
+++ b/src/main/java/com/rackspace/salus/resource_management/config/ResourceManagementProperties.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services.config;
+
+import com.rackspace.salus.resource_management.services.types.KafkaMessageType;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@ConfigurationProperties("resource-management")
+@Component
+@Data
+public class ResourceManagementProperties {
+    Map<KafkaMessageType, String> kafkaTopics;
+}

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services.services;
+
+import com.rackspace.salus.resource_management.services.config.ResourceManagementProperties;
+import com.rackspace.salus.resource_management.services.types.KafkaMessageType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaEgress {
+
+    private final KafkaTemplate kafkaTemplate;
+    private final ResourceManagementProperties properties;
+
+    @Autowired
+    public KafkaEgress(KafkaTemplate kafkaTemplate, ResourceManagementProperties properties) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.properties= properties;
+    }
+
+    public void send(String tenantId, KafkaMessageType messageType, String payload) {
+        final String topic = properties.getKafkaTopics().get(messageType);
+        if (topic == null) {
+            throw new IllegalArgumentException(String.format("No topic configured for %s", messageType));
+        }
+        kafkaTemplate.send(topic, tenantId, payload);
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
@@ -53,8 +53,8 @@ public class KafkaIngress {
      * @throws Exception
      */
     @KafkaListener(topics = "#{__listener.topic}")
-    public void consumeAttachEvents(AttachEvent attachEvent) throws Exception {
-        log.info("Processing new attach event: {}", attachEvent.toString());
+    public void consumeAttachEvents(AttachEvent attachEvent) {
+        log.debug("Processing new attach event: {}", attachEvent.toString());
         resourceManagement.handleEnvoyAttach(attachEvent);
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.resource_management.services.config.ResourceManagementProperties;
+import com.rackspace.salus.resource_management.services.types.KafkaMessageType;
+import com.rackspace.salus.telemetry.events.AttachEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class KafkaIngress {
+
+    private final ObjectMapper objectMapper;
+    private final ResourceManagementProperties properties;
+    private final ResourceManagement resourceManagement;
+    private final String topic;
+
+    @Autowired
+    public KafkaIngress(ObjectMapper objectMapper, ResourceManagementProperties properties, ResourceManagement resourceManagement) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.resourceManagement = resourceManagement;
+        this.topic = this.properties.getKafkaTopics().get(KafkaMessageType.ATTACH);
+    }
+
+    /**
+     * This method is used by the __listener.topic magic in the KafkaListener
+     * @return The topic to consume
+     */
+    public String getTopic() {
+        return this.topic;
+    }
+
+    /**
+     * This receives an envoy attach event from Kafka and passes it to the resource manager to do whatever is needed.
+     * @param cr The AttachEvent read from Kafka.
+     * @throws Exception
+     */
+    @KafkaListener(topics = "#{__listener.topic}")
+    //@KafkaListener(topics = "#{'${resource-management.topics}'.split(',')}")
+    public void consumeAttachEvents(ConsumerRecord<String, String> cr) throws Exception {
+        log.info("Received new resource event from {}: {}", cr.toString(), cr.topic());
+        String value = cr.value();
+        AttachEvent attachEvent = objectMapper.readValue(value, AttachEvent.class);
+        log.info("Processing new attach event: {}", attachEvent.toString());
+        resourceManagement.handleEnvoyAttach(attachEvent);
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.resource_management.services.services;
+package com.rackspace.salus.resource_management.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.resource_management.services.config.ResourceManagementProperties;
-import com.rackspace.salus.resource_management.services.types.KafkaMessageType;
-import com.rackspace.salus.telemetry.events.AttachEvent;
+import com.rackspace.salus.resource_management.config.ResourceManagementProperties;
+import com.rackspace.salus.telemetry.messaging.AttachEvent;
+import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
@@ -30,14 +28,12 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class KafkaIngress {
 
-    private final ObjectMapper objectMapper;
     private final ResourceManagementProperties properties;
     private final ResourceManagement resourceManagement;
     private final String topic;
 
     @Autowired
-    public KafkaIngress(ObjectMapper objectMapper, ResourceManagementProperties properties, ResourceManagement resourceManagement) {
-        this.objectMapper = objectMapper;
+    public KafkaIngress(ResourceManagementProperties properties, ResourceManagement resourceManagement) {
         this.properties = properties;
         this.resourceManagement = resourceManagement;
         this.topic = this.properties.getKafkaTopics().get(KafkaMessageType.ATTACH);
@@ -53,15 +49,11 @@ public class KafkaIngress {
 
     /**
      * This receives an envoy attach event from Kafka and passes it to the resource manager to do whatever is needed.
-     * @param cr The AttachEvent read from Kafka.
+     * @param attachEvent The AttachEvent read from Kafka.
      * @throws Exception
      */
     @KafkaListener(topics = "#{__listener.topic}")
-    //@KafkaListener(topics = "#{'${resource-management.topics}'.split(',')}")
-    public void consumeAttachEvents(ConsumerRecord<String, String> cr) throws Exception {
-        log.info("Received new resource event from {}: {}", cr.toString(), cr.topic());
-        String value = cr.value();
-        AttachEvent attachEvent = objectMapper.readValue(value, AttachEvent.class);
+    public void consumeAttachEvents(AttachEvent attachEvent) throws Exception {
         log.info("Processing new attach event: {}", attachEvent.toString());
         resourceManagement.handleEnvoyAttach(attachEvent);
     }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services.services;
+
+import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
+import com.rackspace.salus.telemetry.events.ResourceEvent;
+import com.rackspace.salus.telemetry.model.*;
+import com.rackspace.salus.telemetry.events.*;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Root;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class ResourceManagement {
+    private final ResourceRepository resourceRepository;
+    private final KafkaEgress kafkaEgress;
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Autowired
+    public ResourceManagement(ResourceRepository resourceRepository, KafkaEgress kafkaEgress, EntityManager entityManager) {
+        this.resourceRepository = resourceRepository;
+        this.kafkaEgress = kafkaEgress;
+        this.entityManager = entityManager;
+    }
+
+    public Resource saveAndPublishResource(Resource resource, Map<String, String> oldLabels, boolean envoyChanged, String operation) {
+        resourceRepository.save(resource);
+        publishResourceEvent(resource, oldLabels, envoyChanged, operation);
+        return resource;
+    }
+
+    public Resource getResource(String tenantId, String identifierName, String identifierValue) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
+        Root<Resource> root = cr.from(Resource.class);
+        Join<Resource, ResourceIdentifier> identifier = root.join(Resource_.resourceIdentifier);
+        cr.select(root).where(cb.and(
+                cb.equal(root.get(Resource_.tenantId), tenantId),
+                cb.equal(identifier.get(ResourceIdentifier_.identifierName), identifierName),
+                cb.equal(identifier.get(ResourceIdentifier_.identifierValue), identifierValue)));
+
+        Resource result;
+        try {
+            result = entityManager.createQuery(cr).getSingleResult();
+        } catch (NoResultException e) {
+            result = null;
+        }
+
+        return result;
+    }
+
+    public List<Resource> getAllResources() {
+        List<Resource> result = new ArrayList<>();
+        resourceRepository.findAll().forEach(result::add);
+        return result;
+    }
+
+    public List<?> getResources(String tenantId) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
+        Root<Resource> root = cr.from(Resource.class);
+        cr.select(root).where(
+                cb.equal(root.get(Resource_.tenantId), tenantId));
+
+        return entityManager.createQuery(cr).getResultList();
+    }
+
+    /**
+    public List<Resource> getResources(String tenantId, Map<String, String> labels) {
+        // use geoff's label search query
+    }*/
+
+    public Stream<Resource> getResources(boolean hasEnvoy) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
+        Root<Resource> root = cr.from(Resource.class);
+
+        cr.select(root).where(
+                cb.equal(root.get(Resource_.presenceMonitoringEnabled), hasEnvoy));
+
+        return entityManager.createQuery(cr).getResultStream();
+    }
+
+    public List<Resource> getResources(String tenantId, boolean hasEnvoy) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
+        Root<Resource> root = cr.from(Resource.class);
+
+        cr.select(root).where(cb.and(
+                cb.equal(root.get(Resource_.tenantId), tenantId),
+                cb.equal(root.get(Resource_.presenceMonitoringEnabled), hasEnvoy)));
+
+        return entityManager.createQuery(cr).getResultList();
+    }
+
+    public Resource updateResource(String tenantId, String identifierName, String identifierValue, Resource updatedValues) throws ResourceAlreadyExists {
+        Resource resource = getResource(tenantId, identifierName, identifierValue);
+
+        if (!resource.getResourceIdentifier().toString().equals(updatedValues.getResourceIdentifier().toString())) {
+            String newIdentifierName = updatedValues.getResourceIdentifier().getIdentifierName();
+            String newIdentifierValue = updatedValues.getResourceIdentifier().getIdentifierValue();
+            Resource existingWithIdentifier = getResource(tenantId, newIdentifierName, newIdentifierValue);
+
+            if (existingWithIdentifier != null) {
+                throw new ResourceAlreadyExists(String.format("Resource already exists with identifier %s on tenant %s",
+                        updatedValues.getResourceIdentifier().toString(), tenantId));
+            }
+        }
+
+        Map<String, String> oldLabels = new HashMap<>(resource.getLabels());
+        boolean envoyChanged = resource.isPresenceMonitoringEnabled() != updatedValues.isPresenceMonitoringEnabled();
+
+        try {
+            log.info("Copying {} to {}.", updatedValues.toString(), resource.toString());
+            nullAwareBeanCopy(resource, updatedValues);
+            log.info("End result is {}", resource.toString());
+        } catch (Exception e) {
+            log.error(e.toString());
+        }
+
+        saveAndPublishResource(resource, oldLabels, envoyChanged, "update");
+
+        return resource;
+    }
+
+    public static void nullAwareBeanCopy(Object dest, Object source) throws IllegalAccessException, InvocationTargetException {
+        new BeanUtilsBean() {
+            @Override
+            public void copyProperty(Object dest, String name, Object value)
+                    throws IllegalAccessException, InvocationTargetException {
+                if(value != null) {
+                    super.copyProperty(dest, name, value);
+                }
+            }
+        }.copyProperties(dest, source);
+    }
+
+    public void removeResource(String tenantId, String identifierName, String identifierValue) {
+        Resource resource = getResource(tenantId, identifierName, identifierValue);
+        if (resource != null) {
+            resourceRepository.deleteById(resource.getId());
+        } else {
+            throw new NotFoundException(String.format("No resource found for %s:%s on tenant %s",
+                    identifierName, identifierValue, tenantId));
+        }
+
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void handleEnvoyAttach(AttachEvent attachEvent) {
+        String tenantId = attachEvent.getTenantId();
+        String identifierName = attachEvent.getIdentifierName();
+        String identifierValue = attachEvent.getIdentifierValue();
+        Map<String, String> labels = attachEvent.getLabels();
+        labels = applyNamespaceToKeys(labels, "envoy");
+
+        ResourceIdentifier identifier = new ResourceIdentifier()
+                .setIdentifierName(identifierName)
+                .setIdentifierValue(identifierValue);
+
+        Resource existing = getResource(tenantId, identifierName, identifierValue);
+
+        if (existing == null) {
+            log.debug("No resource found for new envoy attach");
+            Resource newResource = new Resource()
+                    .setTenantId(tenantId)
+                    .setResourceIdentifier(identifier)
+                    .setLabels(labels)
+                    .setPresenceMonitoringEnabled(true);
+            saveAndPublishResource(newResource, null, true, "create");
+        } else {
+            log.debug("Found existing resource related to envoy: {}", existing.toString());
+            updateEnvoyLabels(existing, labels);
+        }
+    }
+
+    private void updateEnvoyLabels(Resource resource, Map<String, String> envoyLabels) {
+        log.debug("Processing new envoy with {} labels", envoyLabels.size());
+        log.debug("Existing resource has {} labels", resource.getLabels().size());
+        AtomicBoolean updated = new AtomicBoolean(false);
+        Map<String, String> resourceLabels = resource.getLabels();
+        Map<String, String> oldLabels = new HashMap<>(resourceLabels);
+
+        resource.getLabels().forEach((name, value) -> {
+            if (envoyLabels.containsKey(name)) {
+                if (envoyLabels.get(name) != value) {
+                    updated.set(true);
+                    resourceLabels.put(name, value);
+                }
+            } else {
+                updated.set(true);
+                resourceLabels.put(name, value);
+            }
+        });
+        if (updated.get()) {
+            resource.setLabels(resourceLabels);
+            saveAndPublishResource(resource, oldLabels, false, "update");
+        }
+    }
+
+    private void publishResourceEvent(Resource resource, Map<String, String> oldLabels, boolean envoyChanged, String operation) {
+        ResourceEvent event = new ResourceEvent();
+        event.setResource(resource);
+        event.setOldLabels(oldLabels);
+        event.setPresenceMonitorChange(envoyChanged);
+        event.setTenantId(resource.getTenantId());
+        event.setOperation(operation);
+
+        //kafkaEgress.send(resource.getTenantId(), KafkaMessageType.RESOURCE, event);
+    }
+
+    //public Resource migrateResourceToTenant(String oldTenantId, String newTenantId, String identifierName, String identifierValue) {}
+
+    /**
+     * Receives a map of strings and adds the given namespace as a prefix to the key.
+     * @param map The map to modify.
+     * @param namespace Prefix to apply to map's keys.
+     * @return Original map but with the namespace prefix applied to all keys.
+     */
+    private Map<String, String> applyNamespaceToKeys(Map<String, String> map, String namespace) {
+        Map<String, String> prefixedMap = new HashMap<>();
+        map.forEach((name, value) -> {
+            prefixedMap.put(namespace + "." + name, value);
+        });
+        return prefixedMap;
+    }
+
+    private void removePresenceMonitoring(String tenantId, String identifierName, String identifierValue) {
+        Resource resource = getResource(tenantId, identifierName, identifierValue);
+        if (resource == null) {
+            log.debug("No resource found to remove presence monitoring");
+        } else {
+            resource.setPresenceMonitoringEnabled(false);
+            saveAndPublishResource(resource, resource.getLabels(), true, "update");
+        }
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -283,7 +283,7 @@ public class ResourceManagement {
      */
     private void updateEnvoyLabels(Resource resource, Map<String, String> envoyLabels) {
         AtomicBoolean updated = new AtomicBoolean(false);
-        Map<String, String> resourceLabels = resource.getLabels().;
+        Map<String, String> resourceLabels = resource.getLabels();
         Map<String, String> oldLabels = new HashMap<>(resourceLabels);
 
         oldLabels.forEach((name, value) -> {

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
@@ -71,7 +71,7 @@ public class ResourceApi {
     }
 
     @GetMapping("/envoys")
-    public SseEmitter getAllWithEnvoysAsStream() {
+    public SseEmitter getAllWithPresenceMonitoringAsStream() {
         SseEmitter emitter = new SseEmitter();
         ExecutorService nonBlockingService = Executors.newCachedThreadPool();
         Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.controller;
+
+import com.rackspace.salus.resource_management.services.ResourceManagement;
+import com.rackspace.salus.resource_management.web.model.ResourceCreate;
+import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
+import com.rackspace.salus.resource_management.web.event.PaginatedResultsRetrievedEvent;
+import com.rackspace.salus.resource_management.web.event.ResourceCreatedEvent;
+import com.rackspace.salus.resource_management.web.event.SingleResourceRetrievedEvent;
+import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.Resource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class ResourceApi {
+
+    private ResourceManagement resourceManagement;
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    public ResourceApi(ResourceManagement resourceManagement, ApplicationEventPublisher eventPublisher) {
+        this.resourceManagement = resourceManagement;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @GetMapping("/resources")
+    public List<Resource> getAll(@RequestParam(defaultValue = "100") int size,
+                                 @RequestParam(defaultValue = "0") int page,
+                                 UriComponentsBuilder uriBuilder,
+                                 final HttpServletResponse response) {
+
+        Page<Resource> result = resourceManagement.getAllResources(PageRequest.of(page, size));
+        eventPublisher.publishEvent(new PaginatedResultsRetrievedEvent<>(
+                Resource.class, uriBuilder, response, page, result.getTotalPages(), size));
+        return result.getContent();
+    }
+
+    @GetMapping("/envoys")
+    public SseEmitter getAllWithEnvoysAsStream() {
+        SseEmitter emitter = new SseEmitter();
+        ExecutorService nonBlockingService = Executors.newCachedThreadPool();
+        Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);
+        nonBlockingService.execute(() -> {
+            resourcesWithEnvoys.forEach(r -> {
+                try {
+                    emitter.send(r);
+                } catch (IOException e) {
+                    emitter.completeWithError(e);
+                }
+            });
+            emitter.complete();
+        });
+        nonBlockingService.shutdown();
+        return emitter;
+    }
+
+    @GetMapping("/tenant/{tenantId}/resources/{resourceId}")
+    public Resource getByResourceId(@PathVariable String tenantId,
+                                    @PathVariable String resourceId,
+                                    final HttpServletResponse response) throws NotFoundException {
+
+        Resource resource = resourceManagement.getResource(tenantId, resourceId);
+        if (resource == null) {
+            throw new NotFoundException(String.format("No resource found for %s on tenant %s",
+                    resourceId, tenantId));
+        }
+        eventPublisher.publishEvent(new SingleResourceRetrievedEvent(this, response));
+        return resource;
+    }
+
+    @GetMapping("/tenant/{tenantId}")
+    public List<?> getAllForTenant(@PathVariable String tenantId,
+                                   @RequestParam(defaultValue = "100") int size,
+                                   @RequestParam(defaultValue = "0") int page,
+                                   UriComponentsBuilder uriBuilder,
+                                   final HttpServletResponse response) {
+
+        Page<Resource> result = resourceManagement.getResources(tenantId, PageRequest.of(page, size));
+        eventPublisher.publishEvent(new PaginatedResultsRetrievedEvent<>(
+                Resource.class, uriBuilder, response, page, result.getTotalPages(), size));
+        return result.getContent();
+    }
+
+    @PostMapping("/tenant/{tenantId}/resources")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Resource create(@PathVariable String tenantId,
+                           @Valid @RequestBody final ResourceCreate input,
+                           final HttpServletResponse response) throws IllegalArgumentException, ResourceAlreadyExists {
+
+        Resource created = resourceManagement.createResource(tenantId, input);
+        eventPublisher.publishEvent(new ResourceCreatedEvent(this, response, created.getResourceId()));
+
+        return created;
+    }
+
+    @PutMapping("/tenant/{tenantId}/resources/{resourceId}")
+    public Resource update(@PathVariable String tenantId,
+                           @PathVariable String resourceId,
+                           @Valid @RequestBody final ResourceUpdate input,
+                           final HttpServletResponse response) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
+
+        Resource updated = resourceManagement.updateResource(tenantId, resourceId, input);
+        eventPublisher.publishEvent(new SingleResourceRetrievedEvent(this, response));
+
+        return updated;
+    }
+
+    @DeleteMapping("/tenant/{tenantId}/resources/{resourceId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String tenantId,
+                       @PathVariable String resourceId) {
+        resourceManagement.removeResource(tenantId, resourceId);
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/error/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/error/RestExceptionHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.error;
+
+import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class RestExceptionHandler
+        extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = { IllegalArgumentException.class, IllegalStateException.class, ResourceAlreadyExists.class})
+    protected ResponseEntity<Object> handleBadRequest(
+            RuntimeException ex, WebRequest request) {
+        String errorMessage = ex.getMessage();
+        return handleExceptionInternal(ex, errorMessage,
+                new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+
+    @ExceptionHandler(value ={NotFoundException.class})
+    protected ResponseEntity<Object> handleNotFoundRequest(
+            RuntimeException ex, WebRequest request) {
+        String errorMessage = ex.getMessage();
+        return handleExceptionInternal(ex, errorMessage,
+                new HttpHeaders(), HttpStatus.NOT_FOUND, request);
+    }
+
+    /**
+     * This method is triggered by our model validations.
+     * It cannot be included in an @ExceptionHandler so instead we must override.
+     *
+     * @return A message stating the invalid paramater and the reason why it is invalid.
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> String.format("\"%s\" %s", e.getField(), e.getDefaultMessage()))
+                .findFirst()
+                .orElse(ex.getMessage());
+        return handleExceptionInternal(ex, errorMessage,
+                new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/event/PaginatedResultsRetrievedEvent.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/event/PaginatedResultsRetrievedEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.event;
+
+import java.io.Serializable;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Event that is fired when a paginated search is performed.
+ * <p/>
+ * This event object contains all the information needed to create the URL for the paginated results
+ *
+ * @param <T>
+ *            Type of the result that is being handled (commonly Entities).
+ */
+public final class PaginatedResultsRetrievedEvent<T extends Serializable> extends ApplicationEvent {
+    private final UriComponentsBuilder uriBuilder;
+    private final HttpServletResponse response;
+    private final int page;
+    private final int totalPages;
+    private final int pageSize;
+
+    public PaginatedResultsRetrievedEvent(final Class<T> clazz, final UriComponentsBuilder uriBuilderToSet, final HttpServletResponse responseToSet, final int pageToSet, final int totalPagesToSet, final int pageSizeToSet) {
+        super(clazz);
+
+        uriBuilder = uriBuilderToSet;
+        response = responseToSet;
+        page = pageToSet;
+        totalPages = totalPagesToSet;
+        pageSize = pageSizeToSet;
+    }
+
+    // API
+
+    public final UriComponentsBuilder getUriBuilder() {
+        return uriBuilder;
+    }
+
+    public final HttpServletResponse getResponse() {
+        return response;
+    }
+
+    public final int getPage() {
+        return page;
+    }
+
+    public final int getTotalPages() {
+        return totalPages;
+    }
+
+    public final int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * The object on which the Event initially occurred.
+     *
+     * @return The object on which the Event initially occurred.
+     */
+    @SuppressWarnings("unchecked")
+    public final Class<T> getClazz() {
+        return (Class<T>) getSource();
+    }
+
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/event/ResourceCreatedEvent.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/event/ResourceCreatedEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.event;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ResourceCreatedEvent extends ApplicationEvent {
+    private final HttpServletResponse response;
+    private final String idOfNewResource;
+
+    public ResourceCreatedEvent(final Object source, final HttpServletResponse response, final String idOfNewResource) {
+        super(source);
+
+        this.response = response;
+        this.idOfNewResource = idOfNewResource;
+    }
+
+    // API
+
+    public HttpServletResponse getResponse() {
+        return response;
+    }
+
+    public String getIdOfNewResource() {
+        return idOfNewResource;
+    }
+
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/event/SingleResourceRetrievedEvent.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/event/SingleResourceRetrievedEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class SingleResourceRetrievedEvent extends ApplicationEvent {
+    private HttpServletResponse response;
+
+    public SingleResourceRetrievedEvent(Object source,
+                                        HttpServletResponse response) {
+        super(source);
+
+        this.response = response;
+    }
+
+    public HttpServletResponse getResponse() {
+        return response;
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/listener/PaginatedResultsRetrievedDiscoverabilityListener.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/listener/PaginatedResultsRetrievedDiscoverabilityListener.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.listener;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.rackspace.salus.resource_management.web.event.PaginatedResultsRetrievedEvent;
+import com.rackspace.salus.resource_management.web.util.LinkUtil;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.google.common.base.Preconditions;
+import com.google.common.net.HttpHeaders;
+
+@SuppressWarnings({ "rawtypes" })
+@Component
+class PaginatedResultsRetrievedDiscoverabilityListener implements ApplicationListener<PaginatedResultsRetrievedEvent> {
+
+    private static final String PAGE = "page";
+
+    public PaginatedResultsRetrievedDiscoverabilityListener() {
+        super();
+    }
+
+    // API
+
+    @Override
+    public final void onApplicationEvent(final PaginatedResultsRetrievedEvent ev) {
+        Preconditions.checkNotNull(ev);
+
+        addLinkHeaderOnPagedResourceRetrieval(ev.getUriBuilder(), ev.getResponse(), ev.getClazz(), ev.getPage(), ev.getTotalPages(), ev.getPageSize());
+    }
+
+    // - note: at this point, the URI is transformed into plural (added `s`) in a hardcoded way - this will change in the future
+    final void addLinkHeaderOnPagedResourceRetrieval(final UriComponentsBuilder uriBuilder, final HttpServletResponse response, final Class clazz, final int page, final int totalPages, final int pageSize) {
+        plural(uriBuilder, clazz);
+
+        final StringBuilder linkHeader = new StringBuilder();
+        if (hasNextPage(page, totalPages)) {
+            final String uriForNextPage = constructNextPageUri(uriBuilder, page, pageSize);
+            linkHeader.append(LinkUtil.createLinkHeader(uriForNextPage, LinkUtil.REL_NEXT));
+        }
+        if (hasPreviousPage(page)) {
+            final String uriForPrevPage = constructPrevPageUri(uriBuilder, page, pageSize);
+            appendCommaIfNecessary(linkHeader);
+            linkHeader.append(LinkUtil.createLinkHeader(uriForPrevPage, LinkUtil.REL_PREV));
+        }
+        if (hasFirstPage(page)) {
+            final String uriForFirstPage = constructFirstPageUri(uriBuilder, pageSize);
+            appendCommaIfNecessary(linkHeader);
+            linkHeader.append(LinkUtil.createLinkHeader(uriForFirstPage, LinkUtil.REL_FIRST));
+        }
+        if (hasLastPage(page, totalPages)) {
+            final String uriForLastPage = constructLastPageUri(uriBuilder, totalPages, pageSize);
+            appendCommaIfNecessary(linkHeader);
+            linkHeader.append(LinkUtil.createLinkHeader(uriForLastPage, LinkUtil.REL_LAST));
+        }
+
+        if (linkHeader.length() > 0) {
+            response.addHeader(HttpHeaders.LINK, linkHeader.toString());
+        }
+    }
+
+    final String constructNextPageUri(final UriComponentsBuilder uriBuilder, final int page, final int size) {
+        return uriBuilder.replaceQueryParam(PAGE, page + 1).replaceQueryParam("size", size).build().encode().toUriString();
+    }
+
+    final String constructPrevPageUri(final UriComponentsBuilder uriBuilder, final int page, final int size) {
+        return uriBuilder.replaceQueryParam(PAGE, page - 1).replaceQueryParam("size", size).build().encode().toUriString();
+    }
+
+    final String constructFirstPageUri(final UriComponentsBuilder uriBuilder, final int size) {
+        return uriBuilder.replaceQueryParam(PAGE, 0).replaceQueryParam("size", size).build().encode().toUriString();
+    }
+
+    final String constructLastPageUri(final UriComponentsBuilder uriBuilder, final int totalPages, final int size) {
+        return uriBuilder.replaceQueryParam(PAGE, totalPages).replaceQueryParam("size", size).build().encode().toUriString();
+    }
+
+    final boolean hasNextPage(final int page, final int totalPages) {
+        return page < (totalPages - 1);
+    }
+
+    final boolean hasPreviousPage(final int page) {
+        return page > 0;
+    }
+
+    final boolean hasFirstPage(final int page) {
+        return hasPreviousPage(page);
+    }
+
+    final boolean hasLastPage(final int page, final int totalPages) {
+        return (totalPages > 1) && hasNextPage(page, totalPages);
+    }
+
+    final void appendCommaIfNecessary(final StringBuilder linkHeader) {
+        if (linkHeader.length() > 0) {
+            linkHeader.append(", ");
+        }
+    }
+
+    // template
+
+    protected void plural(final UriComponentsBuilder uriBuilder, final Class clazz) {
+        final String resourceName = clazz.getSimpleName().toLowerCase() + "s";
+        uriBuilder.path("/auth/" + resourceName);
+    }
+
+}
+

--- a/src/main/java/com/rackspace/salus/resource_management/web/listener/ResourceCreatedDiscoverabilityListener.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/listener/ResourceCreatedDiscoverabilityListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.listener;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.net.HttpHeaders;
+import com.rackspace.salus.resource_management.web.event.ResourceCreatedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.google.common.base.Preconditions;
+
+@Component
+class ResourceCreatedDiscoverabilityListener implements ApplicationListener<ResourceCreatedEvent> {
+
+    @Override
+    public void onApplicationEvent(final ResourceCreatedEvent resourceCreatedEvent) {
+        Preconditions.checkNotNull(resourceCreatedEvent);
+
+        final HttpServletResponse response = resourceCreatedEvent.getResponse();
+        final String idOfNewResource = resourceCreatedEvent.getIdOfNewResource();
+
+        addLinkHeaderOnResourceCreation(response, idOfNewResource);
+    }
+
+    void addLinkHeaderOnResourceCreation(final HttpServletResponse response, final String idOfNewResource) {
+        final URI uri = ServletUriComponentsBuilder.fromCurrentRequestUri().path("/{idOfNewResource}").buildAndExpand(idOfNewResource).toUri();
+        response.setHeader(HttpHeaders.LOCATION, uri.toASCIIString());
+    }
+
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/listener/SingleResourceRetrievedDiscoverabilityListener.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/listener/SingleResourceRetrievedDiscoverabilityListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.listener;
+
+import com.google.common.base.Preconditions;
+import com.google.common.net.HttpHeaders;
+import com.rackspace.salus.resource_management.web.event.SingleResourceRetrievedEvent;
+import com.rackspace.salus.resource_management.web.util.LinkUtil;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+class SingleResourceRetrievedDiscoverabilityListener
+        implements ApplicationListener<SingleResourceRetrievedEvent> {
+
+    @Override
+    public void onApplicationEvent(SingleResourceRetrievedEvent resourceRetrievedEvent){
+        Preconditions.checkNotNull(resourceRetrievedEvent);
+
+        HttpServletResponse response = resourceRetrievedEvent.getResponse();
+        addLinkHeaderOnSingleResourceRetrieval(response);
+    }
+    private void addLinkHeaderOnSingleResourceRetrieval(HttpServletResponse response){
+        String requestURL = ServletUriComponentsBuilder.fromCurrentRequestUri().
+                build().toUri().toASCIIString();
+        int positionOfLastSlash = requestURL.lastIndexOf("/");
+        String uriForResourceCreation = requestURL.substring(0, positionOfLastSlash);
+
+        String linkHeaderValue = LinkUtil
+                .createLinkHeader(uriForResourceCreation, "collection");
+        response.addHeader(HttpHeaders.LINK, linkHeaderValue);
+    }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.model;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Map;
+
+@Data
+public class ResourceCreate implements Serializable {
+    @NotBlank
+    String resourceId;
+
+    Map<String,String> labels;
+
+    @NotNull
+    Boolean presenceMonitoringEnabled;
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
@@ -17,8 +17,9 @@
 package com.rackspace.salus.resource_management.web.model;
 
 import lombok.Data;
+import org.hibernate.validator.constraints.NotBlank;
 
-import javax.validation.constraints.NotBlank;
+//import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Map;

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceUpdate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceUpdate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.model;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@Data
+public class ResourceUpdate implements Serializable {
+    Map<String,String> labels;
+
+    Boolean presenceMonitoringEnabled;
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/lombok.config
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.accessors.chain = true

--- a/src/main/java/com/rackspace/salus/resource_management/web/util/LinkUtil.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/util/LinkUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.util;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Provides some constants and utility methods to build a Link Header to be stored in the {@link HttpServletResponse} object
+ */
+public final class LinkUtil {
+
+    public static final String REL_COLLECTION = "collection";
+    public static final String REL_NEXT = "next";
+    public static final String REL_PREV = "prev";
+    public static final String REL_FIRST = "first";
+    public static final String REL_LAST = "last";
+
+    private LinkUtil() {
+        throw new AssertionError();
+    }
+
+    //
+
+    /**
+     * Creates a Link Header to be stored in the {@link HttpServletResponse} to provide Discoverability features to the user
+     *
+     * @param uri the base uri
+     * @param rel the relative path
+     * @return the complete url
+     */
+    public static String createLinkHeader(final String uri, final String rel) {
+        return "<" + uri + ">; rel=\"" + rel + "\"";
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5Dialect
     properties:
       hibernate:
-        generate_statistics: true
+        generate_statistics: false
     show-sql: true
   datasource:
     username: dev
@@ -13,9 +13,6 @@ spring:
     url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
     driver-class-name: com.mysql.cj.jdbc.Driver
     platform: mysql
-  kafka:
-    consumer:
-      group-id: resource-managers
 logging:
   level:
     com.rackspace.salus: debug

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.MySQL5Dialect
+    properties:
+      hibernate:
+        generate_statistics: true
+    show-sql: true
+  datasource:
+    username: dev
+    password: pass
+    url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    platform: mysql
+  kafka:
+    consumer:
+      group-id: resource-managers
+logging:
+  level:
+    com.rackspace.salus: debug
+    org.hibernate.type: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8085
 resource-management:
   kafka-topics:
     LOG:
@@ -10,3 +12,23 @@ resource-management:
       attaches
     RESOURCE:
       resources
+spring:
+  kafka:
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: resource-managers
+      auto-offset-reset: latest
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: com.rackspace.salus.telemetry.messaging
+  http:
+    log-request-details: true
+logging:
+  level:
+    web: debug
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+resource-management:
+  kafka-topics:
+    LOG:
+      telemetry.logs.json
+    METRIC:
+      telemetry.metrics.json
+    EVENT:
+      telemetry.events.json
+    ATTACH:
+      attaches
+    RESOURCE:
+      resources

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,9 @@ resource-management:
     EVENT:
       telemetry.events.json
     ATTACH:
-      attaches
+      telemetry.attaches.json
     RESOURCE:
-      resources
+      telemetry.resources.json
 spring:
   kafka:
     producer:

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -1,5 +1,0 @@
-insert into resources
-values(1, "hostname", "testHost", "tenant1");
-
-insert into resources
-values(2, "xen-id", "12345", "tenant2");

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -1,0 +1,5 @@
+insert into resources
+values(1, "hostname", "testHost", "tenant1");
+
+insert into resources
+values(2, "xen-id", "12345", "tenant2");

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.resource_management.services.services.ResourceManagement;
+import com.rackspace.salus.telemetry.model.Resource;
+import com.rackspace.salus.telemetry.model.ResourceIdentifier;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.Collections;
+
+@RunWith(SpringRunner.class)
+//@SpringBootTest
+@EnableJpaRepositories("com.rackspace.salus.telemetry")
+@EntityScan("com.rackspace.salus.telemetry")
+@DataJdbcTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class ResourceManagementTest {
+
+    @Autowired
+    ResourceManagement resourceManagement;
+
+    @Autowired
+    ResourceRepository resourceRepository;
+
+    @Before
+    public void setUp() {
+        Resource resource = new Resource()
+                .setTenantId("abcde")
+                .setResourceIdentifier(new ResourceIdentifier()
+                        .setIdentifierName("host")
+                        .setIdentifierValue("this"))
+                .setLabels(Collections.singletonMap("key", "value"))
+                .setPresenceMonitoringEnabled(false);
+
+        resourceRepository.save(resource);
+    }
+
+    @Test
+    public void testRegisterNewResource() {
+    }
+
+    @Test
+    public void testGetResource() {
+        Resource r = resourceManagement.getResource("abcde", "host", "this");
+
+        assertThat(r.getId(), notNullValue());
+        assertThat(r.getLabels(), hasEntry("key", "value"));
+    }
+
+}
+

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -49,7 +49,6 @@ import java.util.Random;
 import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
-
 @DataJpaTest
 @Import({ResourceManagement.class})
 public class ResourceManagementTest {
@@ -154,8 +153,7 @@ public class ResourceManagementTest {
 
         assertThat(result.getTotalElements(), equalTo(1L));
 
-        // There is already one resource created as default
-        createResourcesForTenant(totalResources - 1, tenantId);
+        createResourcesForTenant(totalResources , tenantId);
 
         page = PageRequest.of(0, 10);
         result = resourceManagement.getResources(tenantId, page);


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-121 - Create Resource Management Service
https://jira.rax.io/browse/SALUS-137 - Resource Management HTTP Interface
https://jira.rax.io/browse/SALUS-138 - Namespace envoy labels

# What

The initial implementation of the Resource Management service.

Adds a REST API service as well as the intermediate service to perform SQL operations.

The API performs CRUD operations for Resource objects.  It has also been configured with custom pagination/error handling to allow for easier integration with Intelligence.

For these requests, the resource management service posts new messages to the resources topic in Kafka for consumption by the Monitoring Management and Presence Monitoring services.  Additionally it consumes new attach events from Kafka to register those resources in SQL.

# How

* `hibernate-jpamodelgen` was added to `salus-telemetry-model` to allow us to query the resources via JPA Metamodel data rather than writing raw sql.
  * This ties in to how we use the CriteriaBuilder in `ResourceManagement.java`
* New `ResourceCreate` and `ResourceUpdate` models were introduced to represent the valid payloads to be received by the API.
* Custom error handling was added in `RestExceptionHandler.java`
* `ApplicationEventPublisher` is used in the API to send events to a listener to add additional header data to the responses to assist with pagination handling by the clients.  These listeners perform their actions synchronously.
* Tests are ran in an embedded h2 database via the inclusion of the `com.h2database` dependency.
* Test data can be auto-populated via `uk.co.jemos.podam`
    * We currently do have to use a deprecated version of `@NotBlank` for this to work.
    * I will look into adding support for the newer version to that project.

## How to test

Currently `ResourceManagementTest.java` can be run.  More API and Kafka tests will be coming in the next PR.

# Why

This service will be queried by the public API as well as by other services to get Resource information.  It is the source of truth for Resource data.

It has to correlate new envoy attachments to existing resources created via the public API and vice-versa.

# TODO
- Add tests
- General cleanup
- Possibly have to add a default sort value to all queries.