### PR TITLE
Parent the pom to the salus-app-base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.1.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
+    <groupId>com.rackspace.salus</groupId>
+    <artifactId>salus-app-base</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../salus-app-base</relativePath>
   </parent>
-  <groupId>com.rackspace.salus</groupId>
+
   <artifactId>salus-telemetry-resource-management</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>salus-telemetry-resource-management</name>


### PR DESCRIPTION
# Resolves

Discovered while looking up MySQL version needed for \SALUS-93

# What

Updates the pom's parent to match our other apps.

# How

Use the salus-app-base as the parent since that standardizes the Spring Boot version used, etc.