### PR TITLE
Re-configure default server port only for dev Spring profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8085
 spring:
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-server:
-  port: 8085
 resource-management:
   kafka-topics:
     LOG:


### PR DESCRIPTION
# Resolves

Part of SALUS-188

# What

Fixing up a convention I had incorrectly started with setting the `server.port` in the main application.yml. Instead we should only override the default 8080 with the `dev` profile activated. Using 8080 keeps the deployment specs consistent.