### PR TITLE
Add query to get resourceIds for given Envoy labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,24 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>client-jar</id>
+            <goals><goal>jar</goal></goals>
+            <configuration>
+              <classifier>client</classifier>
+              <includes>
+                <include>**/web/model/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaIngress.java
@@ -51,7 +51,7 @@ public class KafkaIngress {
      */
     @KafkaListener(topics = "#{__listener.topic}")
     public void consumeAttachEvents(AttachEvent attachEvent) {
-        log.debug("Processing new attach event: {}", attachEvent.toString());
+        log.debug("Processing new attach event: {}", attachEvent);
         resourceManagement.handleEnvoyAttach(attachEvent);
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
@@ -22,21 +22,28 @@ import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import javax.persistence.Query;
-import javax.validation.Valid;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
 
 @Slf4j
 @RestController
@@ -123,5 +130,12 @@ public class ResourceApi {
                                                  @RequestParam Map<String, String> labels) {
 
         return resourceManagement.constructQuery(labels, tenantId);
+    }
+
+    @GetMapping("/tenant/{tenantId}/resourceIds/withEnvoyLabels")
+    public List<String> getResourceIdsWithLabels(@PathVariable String tenantId,
+                                                 @RequestParam Map<String, String> labels) {
+
+        return resourceManagement.getResourceIdsWithEnvoyLabels(labels, tenantId);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ server:
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5Dialect
     properties:
       hibernate:


### PR DESCRIPTION
# Resolves

For end to end integration https://jira.rax.io/browse/SALUS-205

# What

To keep things simple for now and focused on retrieving the resource IDs associated with attached Envoys, I added a query method and REST call focused on returning just the resource IDs given specifically Envoy advertised labels.

## How to test

Added a unit test to simulate an Envoy attach and then querying for its associated resource ID.

# TODO

I'll also push out a PR for the corresponding monitor management changes.