### PR TITLE
Envoy now does namespacing of Envoy discovered labels

### DIFF
--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -244,7 +244,7 @@ public class ResourceManagementTest {
     @Test(expected = IllegalArgumentException.class)
     public void testUserLabelConflictsWithSystemNamespace() {
         final ResourceUpdate update = new ResourceUpdate()
-            .setLabels(Collections.singletonMap(LabelNamespaces.DISCOVERED+".os", "MyCoolOS"));
+            .setLabels(Collections.singletonMap(LabelNamespaces.EVENT_ENGINE_TAGS +".account", "HackedAccount"));
         resourceManagement.updateResource(TENANT, RESOURCE_ID, update);
     }
 }


### PR DESCRIPTION

# Resolves

Part of https://jira.rax.io/browse/SALUS-265

# What

As of https://github.com/racker/salus-telemetry-envoy/pull/34 the Envoy is doing its own namespacing of the labels it discovers, so that no longer needs to be done in the resource manager. It does, however, still need to enforce that a resource update operation does not include user labels that conflict with the system namespaces.

## How to test

Unit test updated