### PR TITLE
Remove envoy label namespace

### DIFF
--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -198,9 +198,8 @@ public class ResourceManagementTest {
         assertThat(resource.getLabels().size(), greaterThan(0));
         assertThat(resource.getLabels().size(), equalTo(attachEvent.getLabels().size()));
         attachEvent.getLabels().forEach((name, value) -> {
-            String prefixedLabel = "envoy." + name;
-            assertTrue(resource.getLabels().containsKey(prefixedLabel));
-            assertThat(resource.getLabels().get(prefixedLabel), equalTo(value));
+            assertTrue(resource.getLabels().containsKey(name));
+            assertThat(resource.getLabels().get(name), equalTo(value));
         });
         assertThat(resource.getResourceId(), equalTo(attachEvent.getResourceId()));
     }


### PR DESCRIPTION
# Resolves

    https://jira.rax.io/browse/SALUS-266

# What

    We decided we didn't want to have label namespaces built into the system and make the user put those in when he sends the labels to query for

# How

    It just rips out the portions that added those namespaces

## How to test

    Run the ResourceManagementTest

# Why

    Not many other ways to remove something other than removing it.
