### PR TITLE
update resource manager for new resource event

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
@@ -19,7 +19,6 @@ package com.rackspace.salus.resource_management.services;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -42,8 +41,7 @@ public class KafkaEgress {
             throw new IllegalArgumentException(String.format("No topic configured for %s", KafkaMessageType.RESOURCE));
         }
 
-        Resource resource = event.getResource();
-        String key = String.format("%s:%s", resource.getTenantId(), resource.getResourceId());
+        String key = String.format("%s:%s", event.getTenantId(), event.getResourceId());
         kafkaTemplate.send(topic, key, event);
     }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -316,8 +316,8 @@ public class ResourceManagementTest {
         assertThat(actualResource.get().getLabels(), equalTo(envoyLabels));
 
         verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
-        assertThat(resourceEventArg.getValue().getResource().getResourceId(), equalTo("r-1"));
-        assertThat(resourceEventArg.getValue().getResource().getLabels(), equalTo(envoyLabels));
+        assertThat(resourceEventArg.getValue().getResourceId(), equalTo("r-1"));
+        assertThat(resourceEventArg.getValue().getTenantId(), equalTo("t-1"));
 
         verifyNoMoreInteractions(kafkaEgress);
     }
@@ -366,8 +366,8 @@ public class ResourceManagementTest {
         assertThat(actualResource.get().getLabels(), equalTo(expectedResourceLabels));
 
         verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
-        assertThat(resourceEventArg.getValue().getResource().getResourceId(), equalTo("r-1"));
-        assertThat(resourceEventArg.getValue().getResource().getLabels(), equalTo(expectedResourceLabels));
+        assertThat(resourceEventArg.getValue().getResourceId(), equalTo("r-1"));
+        assertThat(resourceEventArg.getValue().getTenantId(), equalTo("t-1"));
 
         verifyNoMoreInteractions(kafkaEgress);
     }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-293
depends on: https://github.com/racker/salus-telemetry-model/pull/40

# How

removes the setting of the extra fields that are no longer used by the resource event, when resourceMan creates it.

## How to test

unit tests
