### PR TITLE
Fix updateEnvoyLabels and remove getResourceIdsWithEnvoyLabels

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -48,7 +48,7 @@ steps:
 
   - id: DEPLOY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', '-s', '.mvn/settings.xml']
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root
@@ -62,6 +62,7 @@ steps:
     # Runs the Jib build by using the latest version of the plugin.
     # To use a specific version, configure the plugin in the pom.xml.
     - jib:build
+    - "-B"
     # Skip Tests since it happened in the previous test
     - "-Dmaven.test.skip=true"
     # Ensure we name the image correctly since its not in pom.xml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
 
   - id: DEPLOY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', '-s', '.mvn/settings.xml']
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root

--- a/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
@@ -21,11 +21,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
-@EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
 @EntityScan("com.rackspace.salus.telemetry.model")
 @EnableScheduling
 @EnableSalusKafkaMessaging

--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.repositories;
+
+import com.rackspace.salus.telemetry.model.Resource;
+import java.util.List;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+
+public interface ResourceRepository extends PagingAndSortingRepository<Resource, Long> {
+
+  List<Resource> findAllByTenantId(String tenantId);
+
+}

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -253,6 +253,9 @@ public class ResourceManagement {
         map.from(updatedValues.getLabels())
                 .whenNonNull()
                 .to(resource::setLabels);
+        map.from(updatedValues.getMetadata())
+                .whenNonNull()
+                .to(resource::setMetadata);
         map.from(updatedValues.getPresenceMonitoringEnabled())
                 .whenNonNull()
                 .to(resource::setPresenceMonitoringEnabled);

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -444,33 +444,4 @@ public class ResourceManagement {
         return resources;
     }
 
-    public List<Long> getResourceIdsWithEnvoyLabels(Map<String, String> labels, String tenantId) {
-
-
-        MapSqlParameterSource paramSource = new MapSqlParameterSource();
-        paramSource.addValue("tenantId", tenantId);//AS r JOIN resource_labels AS rl
-
-        StringBuilder builder = new StringBuilder("SELECT id FROM resources WHERE resources.id IN ");
-        builder.append("(SELECT id from resource_labels WHERE id IN (SELECT id FROM resources WHERE tenant_id = :tenantId) AND resources.id IN ");
-        builder.append(" (SELECT id FROM resource_labels WHERE ");
-        int i = 0;
-        for(Map.Entry<String, String> entry : labels.entrySet()) {
-            if(i > 0) {
-                builder.append(" OR ");
-            }
-            builder.append("(labels = :label"+ i +" AND labels_key = :labelKey" + i + ")");
-            paramSource.addValue("label"+i, entry.getValue());
-            paramSource.addValue("labelKey"+i, entry.getKey());
-            i++;
-        }
-        builder.append(" GROUP BY id HAVING COUNT(*) = :i)) ORDER BY resources.id");
-        paramSource.addValue("i", i);
-
-        return new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource()).query(
-                builder.toString(),
-                paramSource,
-                (rs, rowNumber) -> rs.getLong(1)
-
-        );
-    }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApi.java
@@ -130,10 +130,4 @@ public class ResourceApi {
                                                  @RequestParam Map<String, String> labels) {
         return resourceManagement.getResourcesFromLabels(labels, tenantId);
     }
-
-    @GetMapping("/tenant/{tenantId}/resourceIds/withEnvoyLabels")
-    public List<Long> getResourceIdsWithLabels(@PathVariable String tenantId,
-                                                 @RequestParam Map<String, String> labels) throws IllegalArgumentException{
-        return resourceManagement.getResourceIdsWithEnvoyLabels(labels, tenantId);
-    } // remove
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
@@ -16,13 +16,13 @@
 
 package com.rackspace.salus.resource_management.web.model;
 
+import java.io.Serializable;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.NotBlank;
 
 //import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.io.Serializable;
-import java.util.Map;
 
 @Data
 public class ResourceCreate implements Serializable {
@@ -30,6 +30,8 @@ public class ResourceCreate implements Serializable {
     String resourceId;
 
     Map<String,String> labels;
+
+    Map<String,String> metadata;
 
     @NotNull
     Boolean presenceMonitoringEnabled;

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceUpdate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceUpdate.java
@@ -16,14 +16,15 @@
 
 package com.rackspace.salus.resource_management.web.model;
 
-import lombok.Data;
-
 import java.io.Serializable;
 import java.util.Map;
+import lombok.Data;
 
 @Data
 public class ResourceUpdate implements Serializable {
     Map<String,String> labels;
+
+    Map<String,String> metadata;
 
     Boolean presenceMonitoringEnabled;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         generate_statistics: false
-    show-sql: true
+    show-sql: false
   datasource:
     username: dev
     password: pass
@@ -18,6 +18,3 @@ spring:
 logging:
   level:
     com.rackspace.salus: debug
-    org.hibernate.type: trace
-    org.springframework.orm.jpa: debug
-    org.springframework.transaction: debug

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
@@ -16,16 +16,22 @@
 
 package com.rackspace.salus.resource_management;
 
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,7 +40,11 @@ import com.rackspace.salus.resource_management.web.controller.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.model.Resource;
-import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,13 +60,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
-
-import javax.persistence.EntityManagerFactory;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = ResourceApi.class)

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -19,7 +19,6 @@ package com.rackspace.salus.resource_management;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -231,11 +230,11 @@ public class ResourceManagementTest {
 
         final Map<String, String> labelsToQuery = new HashMap<>();
         labelsToQuery.put("os", "DARWIN");
-        final List<Long> resourceIdsWithEnvoyLabels = resourceManagement
-            .getResourceIdsWithEnvoyLabels(labelsToQuery, "tenant-1");
+        final List<Resource> resourceIdsWithEnvoyLabels = resourceManagement
+            .getResourcesFromLabels(labelsToQuery, "tenant-1");
 
         assertThat(resourceIdsWithEnvoyLabels, hasSize(1));
-        assertThat(resourceIdsWithEnvoyLabels, hasItem(resourceByResourceId.getId()));
+        assertThat(resourceIdsWithEnvoyLabels.get(0).getResourceId(), equalTo("development:0"));
     }
 
     @Test
@@ -258,8 +257,8 @@ public class ResourceManagementTest {
         labelsToQuery.put("os", "DARWIN");
         labelsToQuery.put("environment", "localdev");
         labelsToQuery.put("arch", "X86_64");
-        final List<Long> resourceIdsWithEnvoyLabels = resourceManagement
-                .getResourceIdsWithEnvoyLabels(labelsToQuery, "tenant-1");
+        final List<Resource> resourceIdsWithEnvoyLabels = resourceManagement
+                .getResourcesFromLabels(labelsToQuery, "tenant-1");
 
         assertEquals(0, resourceIdsWithEnvoyLabels.size());
 

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -399,6 +399,33 @@ public class ResourceManagementTest {
     }
 
     @Test
+    public void testUpdateExistingResourceWithMetadata() {
+        Resource resource = resourceManagement.getAllResources(PageRequest.of(0, 1)).getContent()
+            .get(0);
+        Map<String, String> newLabels = new HashMap<>(resource.getLabels());
+        newLabels.put("newLabel", "newValue");
+
+        final HashMap<String, String> newMetadata = new HashMap<>();
+        newMetadata.put("local_ip", "127.0.0.1");
+        boolean presenceMonitoring = !resource.getPresenceMonitoringEnabled();
+        ResourceUpdate update = new ResourceUpdate()
+            .setLabels(newLabels)
+            .setMetadata(newMetadata)
+            .setPresenceMonitoringEnabled(presenceMonitoring);
+
+        Resource newResource = resourceManagement.updateResource(
+            resource.getTenantId(),
+            resource.getResourceId(),
+            update
+        );
+
+        assertThat(newResource.getLabels(), equalTo(resource.getLabels()));
+        assertThat(newResource.getMetadata(), equalTo(resource.getMetadata()));
+        assertThat(newResource.getId(), equalTo(resource.getId()));
+        assertThat(newResource.getPresenceMonitoringEnabled(), equalTo(presenceMonitoring));
+    }
+
+    @Test
     public void testRemoveResource() {
         ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.resource_management;
 
+import static com.rackspace.salus.telemetry.model.LabelNamespaces.AGENT;
+import static com.rackspace.salus.telemetry.model.LabelNamespaces.applyNamespace;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
@@ -26,28 +28,35 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.Maps;
+import com.rackspace.salus.resource_management.repositories.ResourceRepository;
 import com.rackspace.salus.resource_management.services.KafkaEgress;
 import com.rackspace.salus.resource_management.services.ResourceManagement;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;
+import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import com.rackspace.salus.telemetry.model.Resource;
-import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -81,6 +90,9 @@ public class ResourceManagementTest {
     @MockBean
     KafkaEgress kafkaEgress;
 
+    @Captor
+    ArgumentCaptor<ResourceEvent> resourceEventArg;
+
     PodamFactory podamFactory = new PodamFactoryImpl();
 
     @Before
@@ -92,6 +104,11 @@ public class ResourceManagementTest {
                 .setPresenceMonitoringEnabled(false);
         entityManager.setFlushMode(FlushModeType.AUTO);
         resourceRepository.save(resource);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resourceRepository.deleteAll();
     }
 
     private void createResources(int count) {
@@ -262,6 +279,95 @@ public class ResourceManagementTest {
 
         assertEquals(0, resourceIdsWithEnvoyLabels.size());
 
+    }
+
+    @Test
+    public void testEnvoyAttach_existingResourceWithNoLabels() {
+        final Resource resource = resourceRepository.save(
+            new Resource()
+                .setResourceId("r-1")
+                .setLabels(Collections.emptyMap())
+                .setTenantId("t-1")
+                .setPresenceMonitoringEnabled(false)
+        );
+        entityManager.flush();
+
+        final Map<String, String> envoyLabels = new HashMap<>();
+        envoyLabels.put(applyNamespace(AGENT, "discovered.hostname"), "h-1");
+        envoyLabels.put(applyNamespace(AGENT, "discovered.os"), "linux");
+        envoyLabels.put(applyNamespace(AGENT, "discovered.arch"), "amd64");
+
+        resourceManagement.handleEnvoyAttach(
+            new AttachEvent()
+            .setEnvoyAddress("localhost:1234")
+            .setEnvoyId("e-1")
+            .setLabels(envoyLabels)
+            .setResourceId("r-1")
+            .setTenantId("t-1")
+        );
+        entityManager.flush();
+
+        final Optional<Resource> actualResource = resourceRepository.findById(resource.getId());
+
+        assertThat(actualResource.isPresent(), equalTo(true));
+        //noinspection OptionalGetWithoutIsPresent
+        assertThat(actualResource.get().getLabels(), equalTo(envoyLabels));
+
+        verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
+        assertThat(resourceEventArg.getValue().getResource().getResourceId(), equalTo("r-1"));
+        assertThat(resourceEventArg.getValue().getResource().getLabels(), equalTo(envoyLabels));
+
+        verifyNoMoreInteractions(kafkaEgress);
+    }
+
+    @Test
+    public void testEnvoyAttach_existingResourceWithChangedLabels() {
+        final Map<String, String> resourceLabels = new HashMap<>();
+        resourceLabels.put(applyNamespace(AGENT, "discovered.hostname"), "old-h-1");
+        resourceLabels.put(applyNamespace(AGENT, "notInNew"), "old-agent-value");
+        resourceLabels.put("nonAgentLabel", "someValue");
+
+        final Resource resource = resourceRepository.save(
+            new Resource()
+                .setResourceId("r-1")
+                .setLabels(resourceLabels)
+                .setTenantId("t-1")
+                .setPresenceMonitoringEnabled(false)
+        );
+        entityManager.flush();
+
+        final Map<String, String> envoyLabels = new HashMap<>();
+        envoyLabels.put(applyNamespace(AGENT, "discovered.hostname"), "new-h-1");
+        envoyLabels.put(applyNamespace(AGENT, "discovered.os"), "linux");
+        envoyLabels.put(applyNamespace(AGENT, "discovered.arch"), "amd64");
+
+        resourceManagement.handleEnvoyAttach(
+            new AttachEvent()
+            .setEnvoyAddress("localhost:1234")
+            .setEnvoyId("e-1")
+            .setLabels(envoyLabels)
+            .setResourceId("r-1")
+            .setTenantId("t-1")
+        );
+        entityManager.flush();
+
+        final Optional<Resource> actualResource = resourceRepository.findById(resource.getId());
+
+        final Map<String, String> expectedResourceLabels = new HashMap<>();
+        expectedResourceLabels.put(applyNamespace(AGENT, "discovered.hostname"), "new-h-1");
+        expectedResourceLabels.put(applyNamespace(AGENT, "discovered.os"), "linux");
+        expectedResourceLabels.put(applyNamespace(AGENT, "discovered.arch"), "amd64");
+        expectedResourceLabels.put("nonAgentLabel", "someValue");
+
+        assertThat(actualResource.isPresent(), equalTo(true));
+        //noinspection OptionalGetWithoutIsPresent
+        assertThat(actualResource.get().getLabels(), equalTo(expectedResourceLabels));
+
+        verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
+        assertThat(resourceEventArg.getValue().getResource().getResourceId(), equalTo("r-1"));
+        assertThat(resourceEventArg.getValue().getResource().getLabels(), equalTo(expectedResourceLabels));
+
+        verifyNoMoreInteractions(kafkaEgress);
     }
 
     @Test
@@ -445,12 +551,11 @@ public class ResourceManagementTest {
         assertEquals(0, resources.size());
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void testSendNoLabels() {
+    @Test
+    public void testGetResourcesFromLabels_noLabels() {
         final Map<String, String> resourceLabels = new HashMap<>();
         resourceLabels.put("os", "DARWIN");
         resourceLabels.put("env", "test");
-        final Map<String, String> labels = new HashMap<>();
 
         ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
         create.setLabels(resourceLabels);
@@ -458,7 +563,10 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
+        List<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId);
+        assertThat(resources, hasSize(1));
+        assertThat(resources.get(0).getTenantId(), equalTo(tenantId));
+        assertThat(resources.get(0).getResourceId(), equalTo(create.getResourceId()));
     }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-305

# What

We had previously identified that `getResourceIdsWithEnvoyLabels` was an awkward method to maintain since it mostly duplicated the other labels query. Since I was already making changes in monitor management, I went ahead and shifted the usage of this "get IDs" variant over to the main "get resources" query.

During testing I also found that `updateEnvoyLabels` wasn't properly handling the case when new envoy labels were added during an update. That also led me to find it needed to leverage the label namespacing to differentiate labels provided via the resource API from those provided during envoy attach.

## How to test

Unit tests were updated