### PR TITLE
Pin salus-telemetry-protocol to 0.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,7 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <scope>compile</scope>
+      <version>0.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>


### PR DESCRIPTION
# What

Now that salus-telemetry-protocol has a released version we need to start shifting references to that rather than snapshot.