### PR TITLE
Add ResourceApiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ kafka-console-consumer --bootstrap-server localhost:9093 --topic telemetry.resou
 
 You can trigger these events to be posted by utilizing some of the API operations below.
 
+# Resource Management REST API Client
+
+Internal clients of the Resource Management REST API can declare a Maven dependency as follows:
+
+```xml
+<dependency>
+  <groupId>com.rackspace.salus</groupId>
+  <artifactId>salus-telemetry-resource-management</artifactId>
+  <version>${resource-management.version}</version>
+  <classifier>client</classifier>
+  <exclusions>
+    <exclusion>
+      <groupId>*</groupId>
+      <artifactId>*</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+```
+
+Included in that artifact is the client implementation `ResourceApiClient`. Refer to the javadoc
+of that class for more information.
+
 # API Operations
 Examples of a subset of the available API operations.
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
             <configuration>
               <classifier>client</classifier>
               <includes>
+                <include>**/web/client/**</include>
                 <include>**/web/model/**</include>
               </includes>
             </configuration>

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.client;
+
+import com.rackspace.salus.telemetry.model.Resource;
+
+/**
+ * This interface declares a subset of internal REST API calls exposed by the Resource Management
+ * service.
+ *
+ * @see ResourceApiClient
+ */
+public interface ResourceApi {
+
+  Resource getByResourceId(String tenantId,
+                           String resourceId);
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -17,6 +17,8 @@
 package com.rackspace.salus.resource_management.web.client;
 
 import com.rackspace.salus.telemetry.model.Resource;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This interface declares a subset of internal REST API calls exposed by the Resource Management
@@ -28,4 +30,7 @@ public interface ResourceApi {
 
   Resource getByResourceId(String tenantId,
                            String resourceId);
+
+  List<Resource> getResourcesWithLabels(String tenantId,
+                                        Map<String, String> labels);
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -17,7 +17,13 @@
 package com.rackspace.salus.resource_management.web.client;
 
 import com.rackspace.salus.telemetry.model.Resource;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This client component provides a small subset of Resource Management REST operations that
@@ -47,6 +53,8 @@ import org.springframework.web.client.RestTemplate;
  */
 public class ResourceApiClient implements ResourceApi {
 
+  public static final ParameterizedTypeReference<List<Resource>> LIST_OF_RESOURCE =
+      new ParameterizedTypeReference<List<Resource>>() {};
   private final RestTemplate restTemplate;
 
   public ResourceApiClient(RestTemplate restTemplate) {
@@ -60,5 +68,23 @@ public class ResourceApiClient implements ResourceApi {
         Resource.class,
         tenantId, resourceId
     );
+  }
+
+  @Override
+  public List<Resource> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
+    String endpoint = "/api/tenant/{tenantId}/resourceLabels";
+    UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
+    for (Map.Entry<String, String> e : labels.entrySet()) {
+      uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
+    }
+    String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
+    ResponseEntity<List<Resource>> resp = restTemplate.exchange(
+        uriString,
+        HttpMethod.GET,
+        null,
+        LIST_OF_RESOURCE
+    );
+
+    return resp.getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -63,11 +65,20 @@ public class ResourceApiClient implements ResourceApi {
 
   @Override
   public Resource getByResourceId(String tenantId, String resourceId) {
-    return restTemplate.getForObject(
-        "/api/tenant/{tenantId}/resources/{resourceId}",
-        Resource.class,
-        tenantId, resourceId
-    );
+    try {
+      return restTemplate.getForObject(
+          "/api/tenant/{tenantId}/resources/{resourceId}",
+          Resource.class,
+          tenantId, resourceId
+      );
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        return null;
+      }
+      else {
+        throw new IllegalArgumentException(e);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.client;
+
+import com.rackspace.salus.telemetry.model.Resource;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * This client component provides a small subset of Resource Management REST operations that
+ * can be called internally by other microservices in Salus.
+ *
+ * <p>
+ *   It is required that the {@link RestTemplate} provided to this instance has been
+ *   configured with the appropriate root URI for locating the resource management service.
+ *   The following is an example of a configuration bean that does that:
+ * </p>
+ *
+ * <pre>
+ {@literal @}Configuration
+ public class RestClientsConfig {
+
+   {@literal @}Bean
+   public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder) {
+     return new ResourceApiClient(
+       restTemplateBuilder
+       .rootUri("http://localhost:8085")
+       .build()
+     );
+   }
+ }
+ * </pre>
+ *
+ */
+public class ResourceApiClient implements ResourceApi {
+
+  private final RestTemplate restTemplate;
+
+  public ResourceApiClient(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
+
+  @Override
+  public Resource getByResourceId(String tenantId, String resourceId) {
+    return restTemplate.getForObject(
+        "/api/tenant/{tenantId}/resources/{resourceId}",
+        Resource.class,
+        tenantId, resourceId
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.resource_management.web.controller;
 
 import com.rackspace.salus.resource_management.services.ResourceManagement;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
@@ -48,12 +49,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Slf4j
 @RestController
 @RequestMapping("/api")
-public class ResourceApi {
+public class ResourceApiController implements ResourceApi {
     private ResourceManagement resourceManagement;
     private TaskExecutor taskExecutor;
 
     @Autowired
-    public ResourceApi(ResourceManagement resourceManagement, TaskExecutor taskExecutor) {
+    public ResourceApiController(ResourceManagement resourceManagement, TaskExecutor taskExecutor) {
         this.resourceManagement = resourceManagement;
         this.taskExecutor = taskExecutor;
     }
@@ -83,6 +84,7 @@ public class ResourceApi {
         return emitter;
     }
 
+    @Override
     @GetMapping("/tenant/{tenantId}/resources/{resourceId}")
     public Resource getByResourceId(@PathVariable String tenantId,
                                     @PathVariable String resourceId) throws NotFoundException {

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -127,6 +127,7 @@ public class ResourceApiController implements ResourceApi {
         resourceManagement.removeResource(tenantId, resourceId);
     }
 
+    @Override
     @GetMapping("/tenant/{tenantId}/resourceLabels")
     public List<Resource> getResourcesWithLabels(@PathVariable String tenantId,
                                                  @RequestParam Map<String, String> labels) {

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.services.ResourceManagement;
-import com.rackspace.salus.resource_management.web.controller.ResourceApi;
+import com.rackspace.salus.resource_management.web.controller.ResourceApiController;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.model.Resource;
@@ -62,7 +62,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(controllers = ResourceApi.class)
+@WebMvcTest(controllers = ResourceApiController.class)
 @AutoConfigureDataJpa
 public class ResourceApiTest {
 

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -17,8 +17,10 @@
 package com.rackspace.salus.resource_management.web.client;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,6 +37,7 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -76,6 +79,16 @@ public class ResourceApiClientTest {
     final Resource resource = resourceApiClient.getByResourceId("t-1", "r-1");
 
     assertThat(resource, equalTo(expectedResource));
+  }
+
+  @Test
+  public void testGetByResourceId_notFound() {
+    mockServer.expect(requestTo("/api/tenant/t-1/resources/r-not-here"))
+        .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    final Resource resource = resourceApiClient.getByResourceId("t-1", "r-not-here");
+
+    assertThat(resource, nullValue());
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.client;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.telemetry.model.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@RestClientTest
+public class ResourceApiClientTest {
+  @Autowired
+  MockRestServiceServer mockServer;
+
+  @Autowired
+  RestTemplateBuilder restTemplateBuilder;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  private RestTemplate restTempate;
+
+  private ResourceApiClient resourceApiClient;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Before
+  public void setUp() throws Exception {
+    restTempate = restTemplateBuilder.build();
+    resourceApiClient = new ResourceApiClient(restTempate);
+  }
+
+  @Test
+  public void getByResourceId() throws JsonProcessingException {
+
+    Resource expectedResource = podamFactory.manufacturePojo(Resource.class);
+    mockServer.expect(requestTo("/api/tenant/t-1/resources/r-1"))
+        .andRespond(withSuccess(
+            objectMapper.writeValueAsString(expectedResource), MediaType.APPLICATION_JSON
+        ));
+
+    final Resource resource = resourceApiClient.getByResourceId("t-1", "r-1");
+
+    assertThat(resource, equalTo(expectedResource));
+  }
+}

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.resource_management.services.ResourceManagement;
+import com.rackspace.salus.telemetry.model.Resource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ResourceApiController.class)
+public class ResourceApiControllerTest {
+
+  @TestConfiguration
+  public static class ExtraTestConfig {
+    @Bean
+    TaskExecutor taskExecutor() {
+      return new SyncTaskExecutor();
+    }
+  }
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ResourceManagement resourceManagement;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Test
+  public void getByResourceId() throws Exception {
+
+    final Resource expectedResource = podamFactory.manufacturePojo(Resource.class);
+    when(resourceManagement.getResource(any(), any()))
+        .thenReturn(expectedResource);
+
+    mvc.perform(get(
+        "/api/tenant/{tenantId}/resources/{resourceId}",
+        "t-1", "r-1"
+    ).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(expectedResource)));
+
+  }
+}

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.resource_management.web.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -25,6 +26,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.services.ResourceManagement;
 import com.rackspace.salus.telemetry.model.Resource;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,5 +82,28 @@ public class ResourceApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(expectedResource)));
 
+  }
+
+  @Test
+  public void testGetResourcesWithLabels() throws Exception {
+
+    final List<Resource> expectedResources = IntStream.range(0, 4)
+        .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
+        .collect(Collectors.toList());
+
+    when(resourceManagement.getResourcesFromLabels(any(), any()))
+        .thenReturn(expectedResources);
+
+    mvc.perform(get(
+        "/api/tenant/{tenantId}/resourceLabels?env=prod",
+        "t-1"
+    ).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(expectedResources)));
+
+    verify(resourceManagement).getResourcesFromLabels(
+        Collections.singletonMap("env", "prod"),
+        "t-1"
+    );
   }
 }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-311

# What

Adds an internal REST API client similar to the [MonitorApiClient](https://github.com/racker/salus-telemetry-monitor-management/blob/master/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java)

# How

So far includes the query method needed by the monitor management when processing a resource event.

## How to test

New unit tests have been added.