### PR TITLE
Add getExpectedEnvoys to API interface

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -25,4 +25,6 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
 
   List<Resource> findAllByTenantId(String tenantId);
 
+  List<Resource> findAllByPresenceMonitoringEnabled(boolean value);
+
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -144,8 +144,8 @@ public class ResourceManagement {
         return new PageImpl<>(resources, page, resources.size());
     }
 
-    public List<Resource> getAllTenantResources(String tenantid) {
-        return resourceRepository.findAllByTenantId(tenantid);
+    public List<Resource> getAllTenantResources(String tenantId) {
+        return resourceRepository.findAllByTenantId(tenantId);
     }
 
     /**
@@ -175,14 +175,7 @@ public class ResourceManagement {
      * @return List of resources.
      */
     public List<Resource> getExpectedEnvoys() {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
-        Root<Resource> root = cr.from(Resource.class);
-
-        cr.select(root).where(
-                cb.equal(root.get(Resource_.presenceMonitoringEnabled), true));
-
-        return entityManager.createQuery(cr).getResultList();
+        return resourceRepository.findAllByPresenceMonitoringEnabled(true);
     }
 
     /**

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -170,6 +170,22 @@ public class ResourceManagement {
     }
 
     /**
+     * Get a list of all resources where the presence monitoring is enabled.
+     *
+     * @return List of resources.
+     */
+    public List<Resource> getExpectedEnvoys() {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Resource> cr = cb.createQuery(Resource.class);
+        Root<Resource> root = cr.from(Resource.class);
+
+        cr.select(root).where(
+                cb.equal(root.get(Resource_.presenceMonitoringEnabled), true));
+
+        return entityManager.createQuery(cr).getResultList();
+    }
+
+    /**
      * Similar to {@link #getResources(boolean presenceMonitoringEnabled) getResources} except restricted to a
      * single tenant, and returns a list.
      * @param tenantId The tenant to select resources from.

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -33,4 +33,6 @@ public interface ResourceApi {
 
   List<Resource> getResourcesWithLabels(String tenantId,
                                         Map<String, String> labels);
+
+  List<Resource> getExpectedEnvoys();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -133,4 +133,17 @@ public class ResourceApiController implements ResourceApi {
                                                  @RequestParam Map<String, String> labels) {
         return resourceManagement.getResourcesFromLabels(labels, tenantId);
     }
+
+    /**
+     * Gets the list of all envoys with presence monitoring enabled.
+     *
+     * This is primary included due to the requirement to implement all interface methods.
+     * In practice, the clients will call getAllWithPresenceMonitoringAsStream.
+     *
+     * @return A list of resources.
+     */
+    @Override
+    public List<Resource> getExpectedEnvoys() {
+        return resourceManagement.getExpectedEnvoys();
+    }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -61,12 +61,11 @@ public class ResourceApiClientTest {
   MockRestServiceServer mockServer;
 
   @Autowired
-  static final ObjectMapper objectMapper = new ObjectMapper();
-
-  @Autowired
   ResourceApiClient resourceApiClient;
 
   private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private static final String SSEHdr = "data:";
 


### PR DESCRIPTION
# What

Adds a new endpoint to the resource api client.

# How

I added it to the interface and then implemented a version of it in both the controller and the client.  It is unlikely the new controller method will be used, as the clients will want to get a streaming result vs. a large bulk payload, however, it had to be implemented since it is defined in the interface.

Implemented a likely unnecessary method seemed like the best option.  The alternatives are defining a default method in the interface that does nothing or moving away from using the interface. 

## How to test

Run tests.

# Why

Presence monitoring now utilizes this api client, and a method for this endpoint was required.