### PR TITLE
WIP: Use streams instead of SseEmitter for expected envoy request

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -18,6 +18,8 @@ package com.rackspace.salus.resource_management.repositories;
 
 import com.rackspace.salus.telemetry.model.Resource;
 import java.util.List;
+import java.util.stream.Stream;
+
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 
@@ -25,6 +27,5 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
 
   List<Resource> findAllByTenantId(String tenantId);
 
-  List<Resource> findAllByPresenceMonitoringEnabled(boolean value);
-
+  Stream<Resource> findAllByPresenceMonitoringEnabledIsTrue();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -170,12 +170,14 @@ public class ResourceManagement {
     }
 
     /**
-     * Get a list of all resources where the presence monitoring is enabled.
+     * Get a stream of all resources where the presence monitoring is enabled.
      *
-     * @return List of resources.
+     * @return Stream of resources.
      */
-    public List<Resource> getExpectedEnvoys() {
-        return resourceRepository.findAllByPresenceMonitoringEnabled(true);
+    public Stream<Resource> getExpectedEnvoys() {
+        try (Stream<Resource> results = resourceRepository.findAllByPresenceMonitoringEnabledIsTrue()) {
+            return results;
+        }
     }
 
     /**

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.resource_management.web.client;
 import com.rackspace.salus.telemetry.model.Resource;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * This interface declares a subset of internal REST API calls exposed by the Resource Management
@@ -34,5 +35,5 @@ public interface ResourceApi {
   List<Resource> getResourcesWithLabels(String tenantId,
                                         Map<String, String> labels);
 
-  List<Resource> getExpectedEnvoys();
+  Stream<Resource> getExpectedEnvoys();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -24,6 +24,8 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -111,7 +113,7 @@ public class ResourceApiClient implements ResourceApi {
   }
 
   @Override
-  public List<Resource> getExpectedEnvoys() {
+  public Stream<Resource> getExpectedEnvoys() {
     String endpoint = "/api/envoys";
     List<Resource> resources = new ArrayList<>();
 
@@ -119,18 +121,16 @@ public class ResourceApiClient implements ResourceApi {
       BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));
       String line;
       while ((line = bufferedReader.readLine()) != null) {
-        if (line.length() > SSEHdr.length())
-          try {
-            Resource resource;
-            // remove the "data:" hdr
-            resource = objectMapper.readValue(line.substring(SSEHdr.length()), Resource.class);
-            resources.add(resource);
-          } catch (IOException e) {
-            log.warn("Failed to parse Resource", e);
-          }
+        try {
+          Resource resource;
+          resource = objectMapper.readValue(line, Resource.class);
+          resources.add(resource);
+        } catch (IOException e) {
+          log.warn("Failed to parse Resource", e);
+        }
       }
       return response;
     });
-    return resources;
+    return resources.stream();
   }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -23,7 +23,6 @@ import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -46,7 +45,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import io.swagger.annotations.*;
 
 
@@ -78,23 +76,6 @@ public class ResourceApiController implements ResourceApi {
 
         return resourceManagement.getAllResources(PageRequest.of(page, size));
 
-    }
-
-    @GetMapping("/envoys")
-    public SseEmitter getAllWithPresenceMonitoringAsStream() {
-        SseEmitter emitter = new SseEmitter();
-        Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);
-        taskExecutor.execute(() -> {
-            resourcesWithEnvoys.forEach(r -> {
-                try {
-                    emitter.send(r);
-                } catch (IOException e) {
-                    emitter.completeWithError(e);
-                }
-            });
-            emitter.complete();
-        });
-        return emitter;
     }
 
     @Override
@@ -155,15 +136,13 @@ public class ResourceApiController implements ResourceApi {
     }
 
     /**
-     * Gets the list of all envoys with presence monitoring enabled.
+     * Gets the stream of all envoys with presence monitoring enabled.
      *
-     * This is primary included due to the requirement to implement all interface methods.
-     * In practice, the clients will call getAllWithPresenceMonitoringAsStream.
-     *
-     * @return A list of resources.
+     * @return A stream of resources.
      */
     @Override
-    public List<Resource> getExpectedEnvoys() {
+    @GetMapping("/envoys")
+    public Stream<Resource> getExpectedEnvoys() {
         return resourceManagement.getExpectedEnvoys();
     }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,16 +119,17 @@ public class ResourceApiClientTest {
 
     StringBuilder responseStream = new StringBuilder();
     for (Resource r : expectedResources) {
-      String line = String.format("%s%s\n", SSEHdr, objectMapper.writeValueAsString(r));
+      String line = String.format("%s\n", objectMapper.writeValueAsString(r));
       responseStream.append(line);
     }
 
     mockServer.expect(requestTo("/api/envoys"))
             .andRespond(withSuccess(responseStream.toString(), MediaType.TEXT_EVENT_STREAM));
 
-    final List<Resource> resources = resourceApiClient.getExpectedEnvoys();
+    final Stream<Resource> resources = resourceApiClient.getExpectedEnvoys();
+    final List<Resource> receivedResources = resources.collect(Collectors.toList());
 
-    assertThat(resources.size(), equalTo(expectedResources.size()));
-    assertThat(resources, equalTo(expectedResources));
+    assertThat(receivedResources, hasSize(expectedResources.size()));
+    assertThat(receivedResources, equalTo(expectedResources));
   }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -106,4 +106,22 @@ public class ResourceApiControllerTest {
         "t-1"
     );
   }
+
+  @Test
+  public void testGetResourcesWithPresenceMonitoringEnabled() throws Exception {
+    final List<Resource> expectedResources = IntStream.range(0, 4)
+            .mapToObj(value -> podamFactory.manufacturePojo(Resource.class).setPresenceMonitoringEnabled(true))
+            .collect(Collectors.toList());
+
+    when(resourceManagement.getExpectedEnvoys())
+            .thenReturn(expectedResources.stream());
+
+    mvc.perform(get(
+            "/api/envoys"
+    ).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(objectMapper.writeValueAsString(expectedResources)));
+
+    verify(resourceManagement).getExpectedEnvoys();
+  }
 }


### PR DESCRIPTION
# What

This doesn't work yet, but rather than throwing it away, I'll keep it here for now in case we stumble upon something that makes it work with Spring MVC.

Rather than using the SseEmitter for our (currently) one streaming api response, we could use some more native/clean options.

# How

This attempts to switch over to just using a `Stream` object, but as suspected it doesn't actually stream the response, it gets passed through as an array of resources.

## How to test

Run tests and manually verify the response output in console.

`ResourceApi` should be improved as it will currently passes if you force the content type with `@GetMapping(value = "/envoys", produces = "application/stream+json")` due to using `stringContainsInOrder` and the current expected string is wrapped in `[ ]`.

# Why
So things are "nicer".  SseEmitter includes junk data in the response that we have to strip out.  Currently it also works differently than any other endpoint.  It would be better if things were more consistent across all.

This could be accomplished with WebFlux, but it's not worth switching over to that for this one thing.

# TODO

If this ever works, we'd have to redeploy the other services that use this api client.
