### PR TITLE
Remove CriteriaBuilder and use repository methods instead

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -28,6 +28,8 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
 
   List<Resource> findAllByTenantId(String tenantId);
 
+  boolean existsByTenantIdAndResourceId(String tenantId, String resourceId);
+
   List<Resource> findAllByPresenceMonitoringEnabled(boolean value);
 
   Page<Resource> findAllByTenantId(String tenantId, Pageable pageable);

--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -18,6 +18,9 @@ package com.rackspace.salus.resource_management.repositories;
 
 import com.rackspace.salus.telemetry.model.Resource;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 
@@ -27,4 +30,9 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
 
   List<Resource> findAllByPresenceMonitoringEnabled(boolean value);
 
+  Page<Resource> findAllByTenantId(String tenantId, Pageable pageable);
+
+  Optional<Resource> findByTenantIdAndResourceId(String tenantId, String resourceId);
+
+  List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -84,6 +84,16 @@ public class ResourceManagement {
     }
 
     /**
+     * Tests whether the resource exists on the given tenant.
+     * @param tenantId The tenant owning the resource.
+     * @param resourceId The unique value representing the resource.
+     * @return True if the resource exists on the tenant, otherwise false.
+     */
+    public boolean exists(String tenantId, String resourceId) {
+        return resourceRepository.existsByTenantIdAndResourceId(tenantId, resourceId);
+    }
+
+    /**
      * Gets an individual resource object by the public facing id.
      * @param tenantId The tenant owning the resource.
      * @param resourceId The unique value representing the resource.
@@ -157,8 +167,7 @@ public class ResourceManagement {
      * @throws ResourceAlreadyExists
      */
     public Resource createResource(String tenantId, @Valid ResourceCreate newResource) throws IllegalArgumentException, ResourceAlreadyExists {
-        Optional<Resource> existing = getResource(tenantId, newResource.getResourceId());
-        if (existing.isPresent()) {
+        if (exists(tenantId, newResource.getResourceId())) {
             throw new ResourceAlreadyExists(String.format("Resource already exists with identifier %s on tenant %s",
                     newResource.getResourceId(), tenantId));
         }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -26,6 +26,7 @@ import com.rackspace.salus.telemetry.model.Resource;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import javax.validation.Valid;
 
@@ -103,12 +104,9 @@ public class ResourceApiController implements ResourceApi {
     public Resource getByResourceId(@PathVariable String tenantId,
                                     @PathVariable String resourceId) throws NotFoundException {
 
-        Resource resource = resourceManagement.getResource(tenantId, resourceId);
-        if (resource == null) {
-            throw new NotFoundException(String.format("No resource found for %s on tenant %s",
-                    resourceId, tenantId));
-        }
-        return resource;
+        Optional<Resource> resource = resourceManagement.getResource(tenantId, resourceId);
+        return resource.orElseThrow(() -> new NotFoundException(String.format("No resource found for %s on tenant %s",
+                    resourceId, tenantId)));
     }
 
     @GetMapping("/tenant/{tenantId}/resources")

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceApiTest.java
@@ -43,6 +43,7 @@ import com.rackspace.salus.telemetry.model.Resource;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -81,7 +82,7 @@ public class ResourceApiTest {
     public void testGetResource() throws Exception {
         Resource resource = podamFactory.manufacturePojo(Resource.class);
         when(resourceManagement.getResource(anyString(), anyString()))
-                .thenReturn(resource);
+                .thenReturn(Optional.of(resource));
 
         String tenantId = RandomStringUtils.randomAlphabetic( 8 );
         String resourceId = RandomStringUtils.randomAlphabetic( 8 );
@@ -97,7 +98,7 @@ public class ResourceApiTest {
     @Test
     public void testNoResourceFound() throws Exception {
         when(resourceManagement.getResource(anyString(), anyString()))
-                .thenReturn(null);
+                .thenReturn(Optional.empty());
 
         String tenantId = RandomStringUtils.randomAlphabetic( 8 );
         String resourceId = RandomStringUtils.randomAlphabetic( 8 );

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -52,6 +52,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -130,10 +131,10 @@ public class ResourceManagementTest {
 
     @Test
     public void testGetResource() {
-        Resource r = resourceManagement.getResource(TENANT, RESOURCE_ID);
-
-        assertThat(r.getId(), notNullValue());
-        assertThat(r.getLabels(), hasEntry("key", "value"));
+        Optional<Resource> r = resourceManagement.getResource(TENANT, RESOURCE_ID);
+        assertTrue(r.isPresent());
+        assertThat(r.get().getId(), notNullValue());
+        assertThat(r.get().getLabels(), hasEntry("key", "value"));
     }
 
     @Test
@@ -150,11 +151,11 @@ public class ResourceManagementTest {
         assertThat(returned.getLabels().size(), greaterThan(0));
         assertTrue(Maps.difference(create.getLabels(), returned.getLabels()).areEqual());
 
-        Resource retrieved = resourceManagement.getResource(tenantId, create.getResourceId());
+        Optional<Resource> retrieved = resourceManagement.getResource(tenantId, create.getResourceId());
 
-        assertThat(retrieved.getResourceId(), equalTo(returned.getResourceId()));
-        assertThat(retrieved.getPresenceMonitoringEnabled(), equalTo(returned.getPresenceMonitoringEnabled()));
-        assertTrue(Maps.difference(returned.getLabels(), retrieved.getLabels()).areEqual());
+        assertThat(retrieved.get().getResourceId(), equalTo(returned.getResourceId()));
+        assertThat(retrieved.get().getPresenceMonitoringEnabled(), equalTo(returned.getPresenceMonitoringEnabled()));
+        assertTrue(Maps.difference(returned.getLabels(), retrieved.get().getLabels()).areEqual());
     }
 
     @Test
@@ -213,19 +214,20 @@ public class ResourceManagementTest {
         AttachEvent attachEvent = podamFactory.manufacturePojo(AttachEvent.class);
         resourceManagement.handleEnvoyAttach(attachEvent);
 
-        final Resource resource = resourceManagement.getResource(
+        final Optional<Resource> resource = resourceManagement.getResource(
                 attachEvent.getTenantId(),
                 attachEvent.getResourceId());
-        assertThat(resource, notNullValue());
-        assertThat(resource.getId(), greaterThan(0L));
-        assertThat(resource.getTenantId(), equalTo(attachEvent.getTenantId()));
-        assertThat(resource.getLabels().size(), greaterThan(0));
-        assertThat(resource.getLabels().size(), equalTo(attachEvent.getLabels().size()));
+        assertTrue(resource.isPresent());
+        assertThat(resource.get(), notNullValue());
+        assertThat(resource.get().getId(), greaterThan(0L));
+        assertThat(resource.get().getTenantId(), equalTo(attachEvent.getTenantId()));
+        assertThat(resource.get().getLabels().size(), greaterThan(0));
+        assertThat(resource.get().getLabels().size(), equalTo(attachEvent.getLabels().size()));
         attachEvent.getLabels().forEach((name, value) -> {
-            assertTrue(resource.getLabels().containsKey(name));
-            assertThat(resource.getLabels().get(name), equalTo(value));
+            assertTrue(resource.get().getLabels().containsKey(name));
+            assertThat(resource.get().getLabels().get(name), equalTo(value));
         });
-        assertThat(resource.getResourceId(), equalTo(attachEvent.getResourceId()));
+        assertThat(resource.get().getResourceId(), equalTo(attachEvent.getResourceId()));
     }
 
     @Test
@@ -244,7 +246,7 @@ public class ResourceManagementTest {
         resourceManagement.handleEnvoyAttach(attachEvent);
         entityManager.flush();
         final Resource resourceByResourceId =
-            resourceManagement.getResource("tenant-1", "development:0");
+            resourceManagement.getResource("tenant-1", "development:0").get();
         assertThat(resourceByResourceId, notNullValue());
 
         final Map<String, String> labelsToQuery = new HashMap<>();
@@ -268,9 +270,10 @@ public class ResourceManagementTest {
                 .setLabels(labels);
         resourceManagement.handleEnvoyAttach(attachEvent);
         entityManager.flush();
-        final Resource resourceByResourceId =
+        final Optional<Resource> resourceByResourceId =
                 resourceManagement.getResource("tenant-1", "development:0");
-        assertThat(resourceByResourceId, notNullValue());
+        assertTrue(resourceByResourceId.isPresent());
+        assertThat(resourceByResourceId.get(), notNullValue());
 
         final Map<String, String> labelsToQuery = new HashMap<>();
         labelsToQuery.put("os", "DARWIN");
@@ -312,7 +315,6 @@ public class ResourceManagementTest {
         final Optional<Resource> actualResource = resourceRepository.findById(resource.getId());
 
         assertThat(actualResource.isPresent(), equalTo(true));
-        //noinspection OptionalGetWithoutIsPresent
         assertThat(actualResource.get().getLabels(), equalTo(envoyLabels));
 
         verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
@@ -362,7 +364,6 @@ public class ResourceManagementTest {
         expectedResourceLabels.put("nonAgentLabel", "someValue");
 
         assertThat(actualResource.isPresent(), equalTo(true));
-        //noinspection OptionalGetWithoutIsPresent
         assertThat(actualResource.get().getLabels(), equalTo(expectedResourceLabels));
 
         verify(kafkaEgress).sendResourceEvent(resourceEventArg.capture());
@@ -449,12 +450,13 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         resourceManagement.createResource(tenantId, create);
 
-        Resource resource = resourceManagement.getResource(tenantId, create.getResourceId());
-        assertThat(resource, notNullValue());
+        Optional<Resource> created = resourceManagement.getResource(tenantId, create.getResourceId());
+        assertTrue(created.isPresent());
+        assertThat(created.get(), notNullValue());
 
         resourceManagement.removeResource(tenantId, create.getResourceId());
-        resource = resourceManagement.getResource(tenantId, create.getResourceId());
-        assertThat(resource, nullValue());
+        Optional<Resource> deleted = resourceManagement.getResource(tenantId, create.getResourceId());
+        assertTrue(!deleted.isPresent());
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -40,6 +40,7 @@ import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
+import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
 import java.util.Collections;
 import java.util.HashMap;
@@ -457,6 +458,12 @@ public class ResourceManagementTest {
         resourceManagement.removeResource(tenantId, create.getResourceId());
         Optional<Resource> deleted = resourceManagement.getResource(tenantId, create.getResourceId());
         assertTrue(!deleted.isPresent());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testRemoveNonExistentMonitor() {
+        String random = RandomStringUtils.randomAlphanumeric(10);
+        resourceManagement.removeResource(random, random);
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -28,6 +28,7 @@ import com.rackspace.salus.resource_management.services.ResourceManagement;
 import com.rackspace.salus.telemetry.model.Resource;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.Test;
@@ -73,7 +74,7 @@ public class ResourceApiControllerTest {
 
     final Resource expectedResource = podamFactory.manufacturePojo(Resource.class);
     when(resourceManagement.getResource(any(), any()))
-        .thenReturn(expectedResource);
+        .thenReturn(Optional.of(expectedResource));
 
     mvc.perform(get(
         "/api/tenant/{tenantId}/resources/{resourceId}",


### PR DESCRIPTION
# What

Removes all the `CriteriaBuilder` logic for building sql queries and replaces it by using standard repository options.

# How

The "how" is fairly obvious.  The only real decision was to start using `Optional` fields where we are getting at most one returned object.  I like this overall, but the downside is it makes the tests a little more tedious due to having to do various `isPresent()` and `get()` calls.

## How to test

Run all tests.  They still work!

# Why

Cleans up the code and standardizes things across all repos.

# TODO

Incoming PRs for monitor management and model repo... I think that'll be it.