### PR TITLE
added new dependency to pom to generate public api documentation HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,42 @@
         </configuration>
       </plugin>
 
+
+
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>3.1.8</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <info>
+                <title>Salus Resource Management</title>
+                <version>0.1.0</version>
+              </info>
+              <outputPath>${project.build.directory}/generated/swagger/public/document.html</outputPath>
+              <swaggerDirectory>${project.build.directory}/generated/swagger/public</swaggerDirectory>
+              <outputFormats>json</outputFormats>
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-hibernate-validations</artifactId>
+            <version>1.5.6</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
# Resolves

    SALUS-355

# What

Convert the Swagger JSON that gets generated for the public API into HTML that can be deployed somewhere

# How

After a tools PR (https://github.com/racker/salus-tools/pull/5) there will be a new location for the generated swagger to be located. This allows us to generate the HTML off of that because I havent figured out how to alter the swagger.json target of of the maven plugin we are using.

## How to test

compile then run the install event for the salus tools PR (https://github.com/racker/salus-tools/pull/5)
run the maven test lifecycle event

# Why

I have looked through the maven plugin documentation and I didn't see a way to just tell that to generate off of multiple files or change the name of the file to generate off of

# TODO

None
