### PR TITLE
ReattachedEnvoyResourceEvent when Envoy attaches to existing resource

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
@@ -16,14 +16,17 @@
 
 package com.rackspace.salus.resource_management.services;
 
+import com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class KafkaEgress {
 
     private final KafkaTemplate<String,Object> kafkaTemplate;
@@ -41,7 +44,8 @@ public class KafkaEgress {
             throw new IllegalArgumentException(String.format("No topic configured for %s", KafkaMessageType.RESOURCE));
         }
 
-        String key = String.format("%s:%s", event.getTenantId(), event.getResourceId());
+        log.debug("Sending event={} on topic={}", event, topic);
+        final String key = KafkaMessageKeyBuilder.buildMessageKey(event);
         kafkaTemplate.send(topic, key, event);
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -23,12 +23,19 @@ import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.ResourceAlreadyExists;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -268,6 +275,14 @@ public class ResourceManagement {
         if (existing.isPresent()) {
             log.debug("Found existing resource related to envoy: {}", existing.toString());
             updateEnvoyLabels(existing.get(), labels);
+
+            kafkaEgress.sendResourceEvent(
+                new ReattachedEnvoyResourceEvent()
+                    .setEnvoyId(attachEvent.getEnvoyId())
+                    .setTenantId(tenantId)
+                    .setResourceId(resourceId)
+            );
+
         } else {
             log.debug("No resource found for new envoy attach");
             Resource newResource = new Resource()

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -376,19 +376,6 @@ public class ResourceManagement {
     }
 
     /**
-     * Publish a resource event to kafka for consumption by other services.
-     * @param resource The updated resource the operation was performed on.
-     */
-    private void publishResourceEvent(Resource resource) {
-        ResourceEvent event = new ResourceEvent();
-        event.setResourceId(resource.getResourceId());
-        event.setTenantId(resource.getTenantId());
-
-        log.debug("Publishing resource event: {}", event);
-        kafkaEgress.sendResourceEvent(event);
-    }
-
-    /**
      * This can be used to force a presence monitoring change if it is currently running but should not be.
      *
      * If the resource no longer exists, we will still send an event in case presence monitoring is still active.

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -67,6 +67,10 @@ public class ResourceManagement {
 
     }
 
+    private void publishResourceEvent(ResourceEvent event) {
+        kafkaEgress.sendResourceEvent(event);
+    }
+
     /**
      * Creates or updates the resource depending on whether the ID already exists.
      * Also sends a resource event to kafka for consumption by other services.
@@ -80,7 +84,7 @@ public class ResourceManagement {
                                            String reattachedEnvoyId) {
         log.debug("Saving resource: {}", resource);
         resourceRepository.save(resource);
-        kafkaEgress.sendResourceEvent(
+        publishResourceEvent(
             new ResourceEvent()
                 .setTenantId(resource.getTenantId())
                 .setResourceId(resource.getResourceId())
@@ -262,7 +266,7 @@ public class ResourceManagement {
                 String.format("No resource found for %s on tenant %s", resourceId, tenantId)));
 
         resourceRepository.deleteById(resource.getId());
-        kafkaEgress.sendResourceEvent(
+        publishResourceEvent(
             new ResourceEvent()
                 .setTenantId(tenantId)
                 .setResourceId(resourceId)
@@ -365,7 +369,7 @@ public class ResourceManagement {
         if (labelsChanged || reattached) {
             // ...then send a resource changed event
 
-            kafkaEgress.sendResourceEvent(
+            publishResourceEvent(
                 new ResourceEvent()
                     .setTenantId(existingResource.getTenantId())
                     .setResourceId(existingResource.getResourceId())

--- a/src/test/java/com/rackspace/salus/resource_management/services/KafkaEgressTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/services/KafkaEgressTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.resource_management.services;
+
+import static org.mockito.Mockito.verify;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
+import com.rackspace.salus.telemetry.messaging.ResourceEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KafkaEgressTest {
+
+  @Mock
+  KafkaTemplate<String,Object> kafkaTemplate;
+  private KafkaEgress kafkaEgress;
+  private KafkaTopicProperties topicProperties;
+
+  @Before
+  public void setUp() {
+    topicProperties = new KafkaTopicProperties();
+    kafkaEgress = new KafkaEgress(kafkaTemplate, topicProperties);
+  }
+
+  @Test
+  public void testSendResourceEvent() {
+    final ResourceEvent event = new ResourceEvent()
+        .setTenantId("t-1")
+        .setResourceId("r-1");
+
+    kafkaEgress.sendResourceEvent(event);
+
+    verify(kafkaTemplate).send(topicProperties.getResources(), "t-1:r-1", event);
+  }
+
+  @Test
+  public void testSendReattachedResourceEvent() {
+    final ResourceEvent event = new ReattachedEnvoyResourceEvent()
+        .setEnvoyId("e-1")
+        .setTenantId("t-1")
+        .setResourceId("r-1");
+
+    kafkaEgress.sendResourceEvent(event);
+
+    verify(kafkaTemplate).send(topicProperties.getResources(), "t-1:r-1", event);
+  }
+}

--- a/src/test/java/com/rackspace/salus/resource_management/services/KafkaEgressTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/services/KafkaEgressTest.java
@@ -19,7 +19,6 @@ package com.rackspace.salus.resource_management.services;
 import static org.mockito.Mockito.verify;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,18 +44,6 @@ public class KafkaEgressTest {
   @Test
   public void testSendResourceEvent() {
     final ResourceEvent event = new ResourceEvent()
-        .setTenantId("t-1")
-        .setResourceId("r-1");
-
-    kafkaEgress.sendResourceEvent(event);
-
-    verify(kafkaTemplate).send(topicProperties.getResources(), "t-1:r-1", event);
-  }
-
-  @Test
-  public void testSendReattachedResourceEvent() {
-    final ResourceEvent event = new ReattachedEnvoyResourceEvent()
-        .setEnvoyId("e-1")
         .setTenantId("t-1")
         .setResourceId("r-1");
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-360

# What

Extends the processing of Envoy attachment events by producing a new `ReattachedEnvoyResourceEvent` event introduced by https://github.com/racker/salus-telemetry-model/pull/52 when the resource already existed. That event will be produced in addition to the resource change event, if there was a change in the resource.

Design background is provided in https://github.com/racker/salus-telemetry-bundle/pull/50

## How to test

Unit tests updated and added.