### PR TITLE
Fix API Pagination

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -28,6 +28,7 @@ import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.resource_management.entities.Resource;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,399 +53,416 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 public class ResourceManagement {
-    private final ResourceRepository resourceRepository;
-    private final KafkaEgress kafkaEgress;
+  private final ResourceRepository resourceRepository;
+  private final KafkaEgress kafkaEgress;
 
-    JdbcTemplate jdbcTemplate;
+  JdbcTemplate jdbcTemplate;
 
-    @Autowired
-    public ResourceManagement(ResourceRepository resourceRepository,
-                              KafkaEgress kafkaEgress,
-                              JdbcTemplate jdbcTemplate) {
-        this.resourceRepository = resourceRepository;
-        this.kafkaEgress = kafkaEgress;
-        this.jdbcTemplate = jdbcTemplate;
+  @Autowired
+  public ResourceManagement(ResourceRepository resourceRepository,
+      KafkaEgress kafkaEgress,
+      JdbcTemplate jdbcTemplate) {
+    this.resourceRepository = resourceRepository;
+    this.kafkaEgress = kafkaEgress;
+    this.jdbcTemplate = jdbcTemplate;
 
+  }
+
+  private void publishResourceEvent(ResourceEvent event) {
+    kafkaEgress.sendResourceEvent(event);
+  }
+
+  /**
+   * Creates or updates the resource depending on whether the ID already exists.
+   * Also sends a resource event to kafka for consumption by other services.
+   *
+   * @param resource The resource object to create/update in the database.
+   * @param labelsChanged
+   * @param reattachedEnvoyId
+   * @return
+   */
+  public Resource saveAndPublishResource(Resource resource, boolean labelsChanged,
+      String reattachedEnvoyId) {
+    log.debug("Saving resource: {}", resource);
+    resourceRepository.save(resource);
+    publishResourceEvent(
+        new ResourceEvent()
+            .setTenantId(resource.getTenantId())
+            .setResourceId(resource.getResourceId())
+            .setLabelsChanged(labelsChanged)
+            .setReattachedEnvoyId(reattachedEnvoyId)
+    );
+    return resource;
+  }
+
+  /**
+   * Tests whether the resource exists on the given tenant.
+   * @param tenantId The tenant owning the resource.
+   * @param resourceId The unique value representing the resource.
+   * @return True if the resource exists on the tenant, otherwise false.
+   */
+  public boolean exists(String tenantId, String resourceId) {
+    return resourceRepository.existsByTenantIdAndResourceId(tenantId, resourceId);
+  }
+
+  /**
+   * Gets an individual resource object by the public facing id.
+   * @param tenantId The tenant owning the resource.
+   * @param resourceId The unique value representing the resource.
+   * @return The resource object.
+   */
+  public Optional<Resource> getResource(String tenantId, String resourceId) {
+    return resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
+  }
+
+  /**
+   * Get a selection of resource objects across all accounts.
+   * @param page The slice of results to be returned.
+   * @return The resources found that match the page criteria.
+   */
+  public Page<Resource> getAllResources(Pageable page) {
+    return resourceRepository.findAll(page);
+  }
+
+  /**
+   * Same as {@link #getAllResources(Pageable page) getAllResources} except restricted to a single tenant.
+   * @param tenantId The tenant to select resources from.
+   * @param page The slice of results to be returned.
+   * @return The resources found for the tenant that match the page criteria.
+   */
+  public Page<Resource> getResources(String tenantId, Pageable page) {
+    return resourceRepository.findAllByTenantId(tenantId, page);
+  }
+
+  public List<Resource> getAllTenantResources(String tenantId) {
+    return resourceRepository.findAllByTenantId(tenantId);
+  }
+  /**
+   * Get all resources where the presence monitoring field matches the parameter provided.
+   * @param presenceMonitoringEnabled Whether presence monitoring is enabled or not.
+   * @return Stream of resources.
+   */
+  public Stream<Resource> getResources(boolean presenceMonitoringEnabled) {
+    return resourceRepository.findAllByPresenceMonitoringEnabled(presenceMonitoringEnabled).stream();
+  }
+
+  /**
+   * Similar to {@link #getResources(boolean presenceMonitoringEnabled) getResources} except restricted to a
+   * single tenant, and returns a list.
+   * @param tenantId The tenant to select resources from.
+   * @param presenceMonitoringEnabled Whether presence monitoring is enabled or not.
+   * @param page The slice of results to be returned.
+   * @return A page or resources matching the given criteria.
+   */
+  public Page<Resource> getResources(String tenantId, boolean presenceMonitoringEnabled, Pageable page) {
+    List<Resource> resources =
+        resourceRepository.findAllByTenantIdAndPresenceMonitoringEnabled(tenantId, presenceMonitoringEnabled);
+
+    return new PageImpl<>(resources, page, resources.size());
+  }
+
+  /**
+   * Create a new resource in the database and publish an event to kafka.
+   * @param tenantId The tenant to create the entity for.
+   * @param newResource The resource parameters to store.
+   * @return The newly created resource.
+   * @throws IllegalArgumentException
+   * @throws AlreadyExistsException
+   */
+  public Resource createResource(String tenantId, @Valid ResourceCreate newResource) throws IllegalArgumentException, AlreadyExistsException {
+    if (exists(tenantId, newResource.getResourceId())) {
+      throw new AlreadyExistsException(String.format("Resource already exists with identifier %s on tenant %s",
+          newResource.getResourceId(), tenantId));
     }
 
-    private void publishResourceEvent(ResourceEvent event) {
-        kafkaEgress.sendResourceEvent(event);
+    if (newResource.getLabels() != null) {
+      checkLabels(newResource.getLabels());
     }
 
-    /**
-     * Creates or updates the resource depending on whether the ID already exists.
-     * Also sends a resource event to kafka for consumption by other services.
-     *
-     * @param resource The resource object to create/update in the database.
-     * @param labelsChanged
-     * @param reattachedEnvoyId
-     * @return
-     */
-    public Resource saveAndPublishResource(Resource resource, boolean labelsChanged,
-                                           String reattachedEnvoyId) {
-        log.debug("Saving resource: {}", resource);
-        resourceRepository.save(resource);
-        publishResourceEvent(
-            new ResourceEvent()
-                .setTenantId(resource.getTenantId())
-                .setResourceId(resource.getResourceId())
-                .setLabelsChanged(labelsChanged)
-                .setReattachedEnvoyId(reattachedEnvoyId)
-        );
-        return resource;
+    Resource resource = new Resource()
+        .setTenantId(tenantId)
+        .setResourceId(newResource.getResourceId())
+        .setLabels(newResource.getLabels())
+        .setMetadata(newResource.getMetadata())
+        .setPresenceMonitoringEnabled(newResource.getPresenceMonitoringEnabled())
+        .setRegion(newResource.getRegion());
+
+    resource = saveAndPublishResource(resource, true, null);
+
+    return resource;
+  }
+
+  /**
+   * Update an existing resource and publish an event to kafka.
+   * @param tenantId The tenant to create the entity for.
+   * @param resourceId The id of the existing resource.
+   * @param updatedValues The new resource parameters to store.
+   * @return The newly updated resource.
+   */
+  public Resource updateResource(String tenantId, String resourceId, @Valid ResourceUpdate updatedValues) {
+    Resource resource = getResource(tenantId, resourceId)
+        .orElseThrow(() -> new NotFoundException(String.format("No resource found for %s on tenant %s",
+            resourceId, tenantId)));
+
+    Map<String, String> oldLabels = new HashMap<>(resource.getLabels());
+    if (updatedValues.getLabels() != null) {
+      checkLabels(updatedValues.getLabels());
+
+      final Map<String, String> mergedLabels = Stream
+          .concat(
+              updatedValues.getLabels().entrySet().stream(),
+              oldLabels.entrySet().stream()
+                  .filter(entry -> labelHasNamespace(entry.getKey(), LabelNamespaces.AGENT))
+          )
+          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+      resource.setLabels(mergedLabels);
     }
 
-    /**
-     * Tests whether the resource exists on the given tenant.
-     * @param tenantId The tenant owning the resource.
-     * @param resourceId The unique value representing the resource.
-     * @return True if the resource exists on the tenant, otherwise false.
-     */
-    public boolean exists(String tenantId, String resourceId) {
-        return resourceRepository.existsByTenantIdAndResourceId(tenantId, resourceId);
-    }
+    PropertyMapper map = PropertyMapper.get();
+    map.from(updatedValues.getMetadata())
+        .whenNonNull()
+        .to(resource::setMetadata);
+    map.from(updatedValues.getPresenceMonitoringEnabled())
+        .whenNonNull()
+        .to(resource::setPresenceMonitoringEnabled);
+    map.from(updatedValues.getRegion())
+        .whenNonNull()
+        .to(resource::setRegion);
 
-    /**
-     * Gets an individual resource object by the public facing id.
-     * @param tenantId The tenant owning the resource.
-     * @param resourceId The unique value representing the resource.
-     * @return The resource object.
-     */
-    public Optional<Resource> getResource(String tenantId, String resourceId) {
-        return resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
-    }
+    saveAndPublishResource(resource, true, null);
 
-    /**
-     * Get a selection of resource objects across all accounts.
-     * @param page The slice of results to be returned.
-     * @return The resources found that match the page criteria.
-     */
-    public Page<Resource> getAllResources(Pageable page) {
-        return resourceRepository.findAll(page);
-    }
+    return resource;
+  }
 
-    /**
-     * Same as {@link #getAllResources(Pageable page) getAllResources} except restricted to a single tenant.
-     * @param tenantId The tenant to select resources from.
-     * @param page The slice of results to be returned.
-     * @return The resources found for the tenant that match the page criteria.
-     */
-    public Page<Resource> getResources(String tenantId, Pageable page) {
-        return resourceRepository.findAllByTenantId(tenantId, page);
+  private void checkLabels(Map<String,String> labels) {
+    for (Entry<String, String> labelEntry : labels.entrySet()) {
+      final String labelName = labelEntry.getKey();
+      if (!LabelNamespaces.validateUserLabel(labelName)) {
+        throw new IllegalArgumentException(String
+            .format("The given label '%s' conflicts with a system namespace",
+                labelName
+            ));
+      }
     }
+  }
 
-    public List<Resource> getAllTenantResources(String tenantId) {
-        return resourceRepository.findAllByTenantId(tenantId);
+  /**
+   * Delete a resource and publish an event to kafka.
+   * @param tenantId The tenant the resource belongs to.
+   * @param resourceId The id of the resource.
+   */
+  public void removeResource(String tenantId, String resourceId) {
+    Resource resource = getResource(tenantId, resourceId).orElseThrow(() ->
+        new NotFoundException(
+            String.format("No resource found for %s on tenant %s", resourceId, tenantId)));
+
+    resourceRepository.deleteById(resource.getId());
+    publishResourceEvent(
+        new ResourceEvent()
+            .setTenantId(tenantId)
+            .setResourceId(resourceId)
+            .setDeleted(true)
+    );
+  }
+
+  /**
+   * Registers or updates resources in the datastore.
+   * Prefixes the labels received from the envoy so they do not clash with any api specified values.
+   *
+   * @param attachEvent The event triggered from the Ambassador by any envoy attachment.
+   */
+  public void handleEnvoyAttach(AttachEvent attachEvent) {
+    log.debug("Handling Envoy attach: {}", attachEvent);
+
+    String tenantId = attachEvent.getTenantId();
+    String resourceId = attachEvent.getResourceId();
+    Map<String, String> labels = attachEvent.getLabels();
+
+    Optional<Resource> existing = getResource(tenantId, resourceId);
+
+    if (existing.isPresent()) {
+      log.debug("Found existing resource related to envoy: {}", existing.get());
+
+      updateEnvoyLabels(existing.get(), labels, attachEvent.getEnvoyId());
+      log.debug("Found existing resource related to envoy: {}", existing.get());
+    } else {
+      log.debug("No resource found for new envoy attach");
+      Resource newResource = new Resource()
+          .setTenantId(tenantId)
+          .setResourceId(resourceId)
+          .setLabels(labels)
+          .setPresenceMonitoringEnabled(true)
+          .setAssociatedWithEnvoy(true);
+      saveAndPublishResource(newResource, true, null);
     }
-    /**
-     * Get all resources where the presence monitoring field matches the parameter provided.
-     * @param presenceMonitoringEnabled Whether presence monitoring is enabled or not.
-     * @return Stream of resources.
-     */
-    public Stream<Resource> getResources(boolean presenceMonitoringEnabled) {
-        return resourceRepository.findAllByPresenceMonitoringEnabled(presenceMonitoringEnabled).stream();
-    }
+  }
 
-    /**
-     * Get a list of all resources where the presence monitoring is enabled.
-     *
-     * @return List of resources.
-     */
-    public List<Resource> getExpectedEnvoys() {
-        return resourceRepository.findAllByPresenceMonitoringEnabled(true);
-    }
+  /**
+   * When provided with a list of envoy labels determine which ones need to be modified and perform an update.
+   * @param existingResource The resource to update.
+   * @param envoyLabels The list of labels received from a newly connected envoy.
+   * @param envoyId
+   * @return the saved resource, if modified, or the given resource otherwise
+   */
+  private void updateEnvoyLabels(Resource existingResource, Map<String, String> envoyLabels,
+      String envoyId) {
+    final Map<String, String> oldResourceLabels = existingResource.getLabels();
+    // Work with a new map to avoid mutating the labels in-place
+    final Map<String, String> resourceLabels = new HashMap<>(oldResourceLabels);
+    final Set<String> newEnvoyLabelKeys = new HashSet<>(envoyLabels.keySet());
 
-    /**
-     * Similar to {@link #getResources(boolean presenceMonitoringEnabled) getResources} except restricted to a
-     * single tenant, and returns a list.
-     * @param tenantId The tenant to select resources from.
-     * @param presenceMonitoringEnabled Whether presence monitoring is enabled or not.
-     * @param page The slice of results to be returned.
-     * @return A page or resources matching the given criteria.
-     */
-    public Page<Resource> getResources(String tenantId, boolean presenceMonitoringEnabled, Pageable page) {
-        List<Resource> resources =
-                resourceRepository.findAllByTenantIdAndPresenceMonitoringEnabled(tenantId, presenceMonitoringEnabled);
+    // The goals are:
+    // 1. don't touch non-agent labels
+    // 2. update envoy labels that have a new value
+    // 3. remove envoy labels not in the given envoy labels
+    // 4. add any new envoy labels
 
-        return new PageImpl<>(resources, page, resources.size());
-    }
-
-    /**
-     * Create a new resource in the database and publish an event to kafka.
-     * @param tenantId The tenant to create the entity for.
-     * @param newResource The resource parameters to store.
-     * @return The newly created resource.
-     * @throws IllegalArgumentException
-     * @throws AlreadyExistsException
-     */
-    public Resource createResource(String tenantId, @Valid ResourceCreate newResource) throws IllegalArgumentException, AlreadyExistsException {
-        if (exists(tenantId, newResource.getResourceId())) {
-            throw new AlreadyExistsException(String.format("Resource already exists with identifier %s on tenant %s",
-                    newResource.getResourceId(), tenantId));
+    boolean labelsChanged = false;
+    for (Entry<String, String> entry : oldResourceLabels.entrySet()) {
+      String k = entry.getKey();
+      String value = entry.getValue();
+      final String envoyLabelValue = envoyLabels.get(k);
+      if (envoyLabelValue != null) {
+        if (!envoyLabelValue.equals(value)) {
+          // goal 2
+          labelsChanged = true;
+          resourceLabels.put(k, envoyLabelValue);
         }
-
-        if (newResource.getLabels() != null) {
-            checkLabels(newResource.getLabels());
-        }
-
-        Resource resource = new Resource()
-                .setTenantId(tenantId)
-                .setResourceId(newResource.getResourceId())
-                .setLabels(newResource.getLabels())
-                .setMetadata(newResource.getMetadata())
-                .setPresenceMonitoringEnabled(newResource.getPresenceMonitoringEnabled())
-                .setRegion(newResource.getRegion());
-
-        resource = saveAndPublishResource(resource, true, null);
-
-        return resource;
+        newEnvoyLabelKeys.remove(k);
+      } else if (labelHasNamespace(k, LabelNamespaces.AGENT)) { // goal 1
+        // goal 3
+        labelsChanged = true;
+        resourceLabels.remove(k);
+      }
     }
 
-    /**
-     * Update an existing resource and publish an event to kafka.
-     * @param tenantId The tenant to create the entity for.
-     * @param resourceId The id of the existing resource.
-     * @param updatedValues The new resource parameters to store.
-     * @return The newly updated resource.
-     */
-    public Resource updateResource(String tenantId, String resourceId, @Valid ResourceUpdate updatedValues) {
-        Resource resource = getResource(tenantId, resourceId)
-                .orElseThrow(() -> new NotFoundException(String.format("No resource found for %s on tenant %s",
-                        resourceId, tenantId)));
-
-        Map<String, String> oldLabels = new HashMap<>(resource.getLabels());
-        if (updatedValues.getLabels() != null) {
-            checkLabels(updatedValues.getLabels());
-
-            final Map<String, String> mergedLabels = Stream
-                .concat(
-                    updatedValues.getLabels().entrySet().stream(),
-                    oldLabels.entrySet().stream()
-                        .filter(entry -> labelHasNamespace(entry.getKey(), LabelNamespaces.AGENT))
-                )
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-            resource.setLabels(mergedLabels);
-        }
-
-        PropertyMapper map = PropertyMapper.get();
-        map.from(updatedValues.getMetadata())
-                .whenNonNull()
-                .to(resource::setMetadata);
-        map.from(updatedValues.getPresenceMonitoringEnabled())
-                .whenNonNull()
-                .to(resource::setPresenceMonitoringEnabled);
-        map.from(updatedValues.getRegion())
-                .whenNonNull()
-                .to(resource::setRegion);
-
-        saveAndPublishResource(resource, true, null);
-
-        return resource;
+    if (!newEnvoyLabelKeys.isEmpty()) {
+      // goal 4
+      newEnvoyLabelKeys.forEach(key -> resourceLabels.put(key, envoyLabels.get(key)));
+      labelsChanged = true;
     }
 
-    private void checkLabels(Map<String,String> labels) {
-        for (Entry<String, String> labelEntry : labels.entrySet()) {
-            final String labelName = labelEntry.getKey();
-            if (!LabelNamespaces.validateUserLabel(labelName)) {
-                throw new IllegalArgumentException(String
-                        .format("The given label '%s' conflicts with a system namespace",
-                                labelName
-                        ));
-            }
-        }
+    // This is a re-attachment if the existing resource was already associated with an Envoy before
+    final boolean reattached = existingResource.isAssociatedWithEnvoy();
+
+    // If the labels changed above or this is first association with Envoy
+    if (labelsChanged || !reattached) {
+      // ...then save it
+
+      existingResource.setAssociatedWithEnvoy(true);
+      existingResource.setLabels(resourceLabels);
+
+      log.debug("Saving resource due to Envoy attachment: {}", existingResource);
+      resourceRepository.save(existingResource);
     }
 
-    /**
-     * Delete a resource and publish an event to kafka.
-     * @param tenantId The tenant the resource belongs to.
-     * @param resourceId The id of the resource.
-     */
-    public void removeResource(String tenantId, String resourceId) {
-        Resource resource = getResource(tenantId, resourceId).orElseThrow(() ->
-            new NotFoundException(
-                String.format("No resource found for %s on tenant %s", resourceId, tenantId)));
+    // If labels changed or this is a re-attachment
+    if (labelsChanged || reattached) {
+      // ...then send a resource changed event
 
-        resourceRepository.deleteById(resource.getId());
-        publishResourceEvent(
-            new ResourceEvent()
-                .setTenantId(tenantId)
-                .setResourceId(resourceId)
-                .setDeleted(true)
-        );
+      publishResourceEvent(
+          new ResourceEvent()
+              .setTenantId(existingResource.getTenantId())
+              .setResourceId(existingResource.getResourceId())
+              .setLabelsChanged(labelsChanged)
+              .setReattachedEnvoyId(reattached ? envoyId : null)
+      );
     }
+  }
 
-    /**
-     * Registers or updates resources in the datastore.
-     * Prefixes the labels received from the envoy so they do not clash with any api specified values.
-     *
-     * @param attachEvent The event triggered from the Ambassador by any envoy attachment.
-     */
-    public void handleEnvoyAttach(AttachEvent attachEvent) {
-        log.debug("Handling Envoy attach: {}", attachEvent);
+  /**
+   * This can be used to force a presence monitoring change if it is currently running but should not be.
+   *
+   * If the resource no longer exists, we will still send an event in case presence monitoring is still active.
+   * This case will also ensure the monitor mgmt service removed any active monitors.
+   *
+   * @param tenantId The tenant associated to the resource.
+   * @param resourceId THe id of the resource we need to disable monitoring of.
+   */
+  private void removePresenceMonitoring(String tenantId, String resourceId) {
+    Resource resource = getResource(tenantId, resourceId).orElse(
+        new Resource().setTenantId(tenantId).setResourceId(resourceId)
+    );
+    resource.setPresenceMonitoringEnabled(false);
+    saveAndPublishResource(resource, false, null);
+  }
 
-        String tenantId = attachEvent.getTenantId();
-        String resourceId = attachEvent.getResourceId();
-        Map<String, String> labels = attachEvent.getLabels();
-
-        Optional<Resource> existing = getResource(tenantId, resourceId);
-
-        if (existing.isPresent()) {
-            log.debug("Found existing resource related to envoy: {}", existing.get());
-
-            updateEnvoyLabels(existing.get(), labels, attachEvent.getEnvoyId());
-            log.debug("Found existing resource related to envoy: {}", existing.get());
-        } else {
-            log.debug("No resource found for new envoy attach");
-            Resource newResource = new Resource()
-                    .setTenantId(tenantId)
-                    .setResourceId(resourceId)
-                    .setLabels(labels)
-                    .setPresenceMonitoringEnabled(true)
-                    .setAssociatedWithEnvoy(true);
-            saveAndPublishResource(newResource, true, null);
-        }
-    }
-
-    /**
-     * When provided with a list of envoy labels determine which ones need to be modified and perform an update.
-     * @param existingResource The resource to update.
-     * @param envoyLabels The list of labels received from a newly connected envoy.
-     * @param envoyId
-     * @return the saved resource, if modified, or the given resource otherwise
-     */
-    private void updateEnvoyLabels(Resource existingResource, Map<String, String> envoyLabels,
-                                       String envoyId) {
-        final Map<String, String> oldResourceLabels = existingResource.getLabels();
-        // Work with a new map to avoid mutating the labels in-place
-        final Map<String, String> resourceLabels = new HashMap<>(oldResourceLabels);
-        final Set<String> newEnvoyLabelKeys = new HashSet<>(envoyLabels.keySet());
-
-        // The goals are:
-        // 1. don't touch non-agent labels
-        // 2. update envoy labels that have a new value
-        // 3. remove envoy labels not in the given envoy labels
-        // 4. add any new envoy labels
-
-        boolean labelsChanged = false;
-        for (Entry<String, String> entry : oldResourceLabels.entrySet()) {
-            String k = entry.getKey();
-            String value = entry.getValue();
-            final String envoyLabelValue = envoyLabels.get(k);
-            if (envoyLabelValue != null) {
-                if (!envoyLabelValue.equals(value)) {
-                    // goal 2
-                    labelsChanged = true;
-                    resourceLabels.put(k, envoyLabelValue);
-                }
-                newEnvoyLabelKeys.remove(k);
-            } else if (labelHasNamespace(k, LabelNamespaces.AGENT)) { // goal 1
-                // goal 3
-                labelsChanged = true;
-                resourceLabels.remove(k);
-            }
-        }
-
-        if (!newEnvoyLabelKeys.isEmpty()) {
-            // goal 4
-            newEnvoyLabelKeys.forEach(key -> resourceLabels.put(key, envoyLabels.get(key)));
-            labelsChanged = true;
-        }
-
-        // This is a re-attachment if the existing resource was already associated with an Envoy before
-        final boolean reattached = existingResource.isAssociatedWithEnvoy();
-
-        // If the labels changed above or this is first association with Envoy
-        if (labelsChanged || !reattached) {
-            // ...then save it
-
-            existingResource.setAssociatedWithEnvoy(true);
-            existingResource.setLabels(resourceLabels);
-
-            log.debug("Saving resource due to Envoy attachment: {}", existingResource);
-            resourceRepository.save(existingResource);
-        }
-
-        // If labels changed or this is a re-attachment
-        if (labelsChanged || reattached) {
-            // ...then send a resource changed event
-
-            publishResourceEvent(
-                new ResourceEvent()
-                    .setTenantId(existingResource.getTenantId())
-                    .setResourceId(existingResource.getResourceId())
-                    .setLabelsChanged(labelsChanged)
-                    .setReattachedEnvoyId(reattached ? envoyId : null)
-            );
-        }
-    }
-
-    /**
-     * This can be used to force a presence monitoring change if it is currently running but should not be.
-     *
-     * If the resource no longer exists, we will still send an event in case presence monitoring is still active.
-     * This case will also ensure the monitor mgmt service removed any active monitors.
-     *
-     * @param tenantId The tenant associated to the resource.
-     * @param resourceId THe id of the resource we need to disable monitoring of.
-     */
-    private void removePresenceMonitoring(String tenantId, String resourceId) {
-        Resource resource = getResource(tenantId, resourceId).orElse(
-                new Resource().setTenantId(tenantId).setResourceId(resourceId)
-        );
-        resource.setPresenceMonitoringEnabled(false);
-        saveAndPublishResource(resource, false, null);
-    }
-
-    /**
-     * takes in a Mapping of labels for a tenant, builds and runs the query to match to those labels
-     * @param labels the labels that we need to match to
-     * @param tenantId The tenant associated to the resource
-     * @return the list of Resource's that match the labels or all tenant resources if no labels
-     * given
-     */
-    public List<Resource> getResourcesFromLabels(Map<String, String> labels, String tenantId) {
+  /**
+   * takes in a Mapping of labels for a tenant, builds and runs the query to match to those labels
+   * @param labels the labels that we need to match to
+   * @param tenantId The tenant associated to the resource
+   * @return the list of Resource's that match the labels or all tenant resources if no labels
+   * given
+   */
+  public Page<Resource> getResourcesFromLabels(Map<String, String> labels, String tenantId, Pageable page) {
         /*
         SELECT * FROM resources where id IN (SELECT id from resource_labels WHERE id IN (select id from resources)
         AND ((labels = "windows" AND labels_key = "os") OR (labels = "prod" AND labels_key="env")) GROUP BY id
         HAVING COUNT(id) = 2) AND tenant_id = "aaaad";
         */
 
-        if(labels == null || labels.isEmpty()) {
-            return getAllTenantResources(tenantId);
-        }
-
-        MapSqlParameterSource paramSource = new MapSqlParameterSource();
-        paramSource.addValue("tenantId", tenantId);//AS r JOIN resource_labels AS rl
-        StringBuilder builder = new StringBuilder("SELECT resources.id as id FROM resources JOIN resource_labels AS rl WHERE resources.id = rl.id AND resources.id IN ");
-        builder.append("(SELECT id from resource_labels WHERE id IN ( SELECT id FROM resources WHERE tenant_id = :tenantId) AND resources.id IN ");
-        builder.append(" (SELECT id FROM resource_labels WHERE ");
-        int i = 0;
-        for(Map.Entry<String, String> entry : labels.entrySet()) {
-            if(i > 0) {
-                builder.append(" OR ");
-            }
-            builder.append("(labels = :label").append(i)
-                    .append(" AND labels_key = :labelKey").append(i)
-                    .append(")");
-            paramSource.addValue("label"+i, entry.getValue());
-            paramSource.addValue("labelKey"+i, entry.getKey());
-            i++;
-        }
-        builder.append(" GROUP BY id HAVING COUNT(*) = :i)) ORDER BY resources.id");
-        paramSource.addValue("i", i);
-
-        NamedParameterJdbcTemplate namedParameterTemplate = new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource());
-        final List<Long> resourceIds = namedParameterTemplate.query(builder.toString(), paramSource,
-            (resultSet, rowIndex) -> resultSet.getLong(1)
-        );
-
-        final List<Resource> resources = new ArrayList<>();
-        for (Resource resource : resourceRepository.findAllById(resourceIds)) {
-            resources.add(resource);
-        }
-
-        return resources;
+    if(labels == null || labels.isEmpty()) {
+      return getPagedResults(getAllTenantResources(tenantId), page);
     }
+
+    MapSqlParameterSource paramSource = new MapSqlParameterSource();
+    paramSource.addValue("tenantId", tenantId);//AS r JOIN resource_labels AS rl
+    StringBuilder builder = new StringBuilder("SELECT resources.id as id FROM resources JOIN resource_labels AS rl WHERE resources.id = rl.id AND resources.id IN ");
+    builder.append("(SELECT id from resource_labels WHERE id IN ( SELECT id FROM resources WHERE tenant_id = :tenantId) AND resources.id IN ");
+    builder.append(" (SELECT id FROM resource_labels WHERE ");
+    int i = 0;
+    for(Map.Entry<String, String> entry : labels.entrySet()) {
+      if(i > 0) {
+        builder.append(" OR ");
+      }
+      builder.append("(labels = :label").append(i)
+          .append(" AND labels_key = :labelKey").append(i)
+          .append(")");
+      paramSource.addValue("label"+i, entry.getValue());
+      paramSource.addValue("labelKey"+i, entry.getKey());
+      i++;
+    }
+    builder.append(" GROUP BY id HAVING COUNT(*) = :i)) ORDER BY resources.id");
+    paramSource.addValue("i", i);
+
+    NamedParameterJdbcTemplate namedParameterTemplate = new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource());
+    final List<Long> resourceIds = namedParameterTemplate.query(builder.toString(), paramSource,
+        (resultSet, rowIndex) -> resultSet.getLong(1)
+    );
+
+    final List<Resource> resources = new ArrayList<>();
+    for (Resource resource : resourceRepository.findAllById(resourceIds)) {
+      resources.add(resource);
+    }
+
+    return getPagedResults(resources, page);
+  }
+
+  /**
+   * Converts a list of resources into a Page containing only the requested elements.
+   * @param resources The full list of resources found.
+   * @param page The page details that were requested.
+   * @return A Page object containing only the resources that were requested.
+   */
+  @SuppressWarnings("Duplicates")
+  private Page<Resource> getPagedResults(List<Resource> resources, Pageable page) {
+    if (page.isPaged()) {
+      int start = page.getPageSize() * page.getPageNumber();
+      int end = start + page.getPageSize();
+      if (end > resources.size()) {
+        end = resources.size();
+      }
+      List<Resource> results;
+      try {
+        results = resources.subList(start, end);
+      } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+        results = Collections.emptyList();
+      }
+      return new PageImpl<>(results, page, resources.size());
+    } else {
+      return new PageImpl<>(resources, page, resources.size());
+    }
+  }
 
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -18,7 +18,6 @@ package com.rackspace.salus.resource_management.web.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.resource_management.services.ResourceManagement;
-import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
@@ -28,10 +27,8 @@ import com.rackspace.salus.resource_management.entities.Resource;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import com.rackspace.salus.telemetry.model.View;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.Valid;
 
@@ -39,7 +36,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -66,119 +63,98 @@ import io.swagger.annotations.*;
         })
 })
 @RequestMapping("/api")
-public class ResourceApiController implements ResourceApi {
-    private ResourceManagement resourceManagement;
-    private TaskExecutor taskExecutor;
+public class ResourceApiController {
+  private ResourceManagement resourceManagement;
+  private TaskExecutor taskExecutor;
 
-    @Autowired
-    public ResourceApiController(ResourceManagement resourceManagement, TaskExecutor taskExecutor) {
-        this.resourceManagement = resourceManagement;
-        this.taskExecutor = taskExecutor;
-    }
+  @Autowired
+  public ResourceApiController(ResourceManagement resourceManagement, TaskExecutor taskExecutor) {
+    this.resourceManagement = resourceManagement;
+    this.taskExecutor = taskExecutor;
+  }
 
-    @GetMapping("/resources")
-    @JsonView(View.Admin.class)
-    @ApiOperation(value = "Gets all Resources irrespective of Tenant")
-    public PagedContent<ResourceDTO> getAll(@RequestParam(defaultValue = "100") int size,
-                                 @RequestParam(defaultValue = "0") int page) {
+  @GetMapping("/admin/resources")
+  @JsonView(View.Admin.class)
+  @ApiOperation(value = "Gets all Resources irrespective of Tenant")
+  public PagedContent<ResourceDTO> getAll(Pageable pageable) {
 
-        return PagedContent.fromPage(resourceManagement.getAllResources(PageRequest.of(page, size))
-            .map(Resource::toDTO));
-    }
+    return PagedContent.fromPage(resourceManagement.getAllResources(pageable)
+        .map(Resource::toDTO));
+  }
 
-    @GetMapping("/envoys")
-    @JsonView(View.Admin.class)
-    public SseEmitter getAllWithPresenceMonitoringAsStream() {
-        SseEmitter emitter = new SseEmitter();
-        Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);
-        taskExecutor.execute(() -> {
-            resourcesWithEnvoys.forEach(r -> {
-                try {
-                    emitter.send(r.toDTO());
-                } catch (IOException e) {
-                    emitter.completeWithError(e);
-                }
-            });
-            emitter.complete();
-        });
-        return emitter;
-    }
+  @GetMapping("/envoys")
+  @JsonView(View.Admin.class)
+  public SseEmitter getAllWithPresenceMonitoringAsStream() {
+    SseEmitter emitter = new SseEmitter();
+    Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);
+    taskExecutor.execute(() -> {
+      resourcesWithEnvoys.forEach(r -> {
+        try {
+          emitter.send(r.toDTO());
+        } catch (IOException e) {
+          emitter.completeWithError(e);
+        }
+      });
+      emitter.complete();
+    });
+    return emitter;
+  }
 
-    @Override
-    @GetMapping("/tenant/{tenantId}/resources/{resourceId}")
-    @ApiOperation(value = "Gets specific Resource for specific Tenant")
-    @JsonView(View.Public.class)
-    public ResourceDTO getByResourceId(@PathVariable String tenantId,
-                                    @PathVariable String resourceId) throws NotFoundException {
+  @GetMapping("/tenant/{tenantId}/resources/{resourceId}")
+  @ApiOperation(value = "Gets specific Resource for specific Tenant")
+  @JsonView(View.Public.class)
+  public ResourceDTO getByResourceId(@PathVariable String tenantId,
+      @PathVariable String resourceId) throws NotFoundException {
 
-        Optional<Resource> resource = resourceManagement.getResource(tenantId, resourceId);
-        return resource.map(Resource::toDTO).orElseThrow(() -> new NotFoundException(String.format("No resource found for %s on tenant %s",
-                    resourceId, tenantId)));
-    }
+    Optional<Resource> resource = resourceManagement.getResource(tenantId, resourceId);
+    return resource.map(Resource::toDTO).orElseThrow(() -> new NotFoundException(String.format("No resource found for %s on tenant %s",
+        resourceId, tenantId)));
+  }
 
-    @GetMapping("/tenant/{tenantId}/resources")
-    @ApiOperation(value = "Gets all Resources for authenticated tenant")
-    @JsonView(View.Public.class)
-    public PagedContent<ResourceDTO>  getAllForTenant(@PathVariable String tenantId,
-                                   @RequestParam(defaultValue = "100") int size,
-                                   @RequestParam(defaultValue = "0") int page) {
+  @GetMapping("/tenant/{tenantId}/resources")
+  @ApiOperation(value = "Gets all Resources for authenticated tenant")
+  @JsonView(View.Public.class)
+  public PagedContent<ResourceDTO>  getAllForTenant(@PathVariable String tenantId, Pageable pageable) {
 
-        return PagedContent.fromPage(resourceManagement.getResources(tenantId, PageRequest.of(page, size))
-            .map(Resource::toDTO));
-    }
+    return PagedContent.fromPage(resourceManagement.getResources(tenantId, pageable)
+        .map(Resource::toDTO));
+  }
 
-    @PostMapping("/tenant/{tenantId}/resources")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "Create one Resource for Tenant")
-    @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Resource")})
-    @JsonView(View.Public.class)
-    public ResourceDTO create(@PathVariable String tenantId,
-                           @Valid @RequestBody final ResourceCreate input)
-            throws IllegalArgumentException, AlreadyExistsException {
-        return resourceManagement.createResource(tenantId, input).toDTO();
-    }
+  @PostMapping("/tenant/{tenantId}/resources")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Create one Resource for Tenant")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Resource")})
+  @JsonView(View.Public.class)
+  public ResourceDTO create(@PathVariable String tenantId,
+      @Valid @RequestBody final ResourceCreate input)
+      throws IllegalArgumentException, AlreadyExistsException {
+    return resourceManagement.createResource(tenantId, input).toDTO();
+  }
 
-    @PutMapping("/tenant/{tenantId}/resources/{resourceId}")
-    @ApiOperation(value = "Updates specific Resource for Tenant")
-    @JsonView(View.Public.class)
-    public ResourceDTO update(@PathVariable String tenantId,
-                           @PathVariable String resourceId,
-                           @Valid @RequestBody final ResourceUpdate input) throws IllegalArgumentException {
-        return resourceManagement.updateResource(tenantId, resourceId, input).toDTO();
-    }
+  @PutMapping("/tenant/{tenantId}/resources/{resourceId}")
+  @ApiOperation(value = "Updates specific Resource for Tenant")
+  @JsonView(View.Public.class)
+  public ResourceDTO update(@PathVariable String tenantId,
+      @PathVariable String resourceId,
+      @Valid @RequestBody final ResourceUpdate input) throws IllegalArgumentException {
+    return resourceManagement.updateResource(tenantId, resourceId, input).toDTO();
+  }
 
-    @DeleteMapping("/tenant/{tenantId}/resources/{resourceId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @ApiOperation(value = "Gets all Resources for authenticated tenant")
-    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource Deleted")})
-    @JsonView(View.Public.class)
-    public void delete(@PathVariable String tenantId,
-                       @PathVariable String resourceId) {
-        resourceManagement.removeResource(tenantId, resourceId);
-    }
+  @DeleteMapping("/tenant/{tenantId}/resources/{resourceId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiOperation(value = "Gets all Resources for authenticated tenant")
+  @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource Deleted")})
+  @JsonView(View.Public.class)
+  public void delete(@PathVariable String tenantId,
+      @PathVariable String resourceId) {
+    resourceManagement.removeResource(tenantId, resourceId);
+  }
 
-    @Override
-    @GetMapping("/tenant/{tenantId}/resourceLabels")
-    @JsonView(View.Public.class)
-    public List<ResourceDTO> getResourcesWithLabels(@PathVariable String tenantId,
-                                                 @RequestParam Map<String, String> labels) {
-        return resourceManagement.getResourcesFromLabels(labels, tenantId).stream()
-            .map(Resource::toDTO)
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Gets the list of all envoys with presence monitoring enabled.
-     *
-     * This is primary included due to the requirement to implement all interface methods.
-     * In practice, the clients will call getAllWithPresenceMonitoringAsStream.
-     *
-     * @return A list of resources.
-     */
-    @Override
-    public List<ResourceDTO> getExpectedEnvoys() {
-        return resourceManagement.getExpectedEnvoys().stream()
-            .map(Resource::toDTO)
-            .collect(Collectors.toList());
-    }
+  @GetMapping("/tenant/{tenantId}/resourceLabels")
+  @JsonView(View.Public.class)
+  public PagedContent<ResourceDTO> getResourcesWithLabels(@PathVariable String tenantId,
+      @RequestParam Map<String, String> labels, Pageable pageable) {
+    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, pageable)
+        .map(Resource::toDTO));
+  }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -21,7 +21,6 @@ import static com.rackspace.salus.telemetry.model.LabelNamespaces.applyNamespace
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -72,6 +71,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @Import({ResourceManagement.class})
@@ -250,11 +250,11 @@ public class ResourceManagementTest {
 
         final Map<String, String> labelsToQuery = new HashMap<>();
         labelsToQuery.put("os", "DARWIN");
-        final List<Resource> resourceIdsWithEnvoyLabels = resourceManagement
-            .getResourcesFromLabels(labelsToQuery, "tenant-1");
+        final Page<Resource> resourceIdsWithEnvoyLabels = resourceManagement
+            .getResourcesFromLabels(labelsToQuery, "tenant-1", Pageable.unpaged());
 
-        assertThat(resourceIdsWithEnvoyLabels, hasSize(1));
-        assertThat(resourceIdsWithEnvoyLabels.get(0).getResourceId(), equalTo("development:0"));
+        assertThat(resourceIdsWithEnvoyLabels.getTotalElements(), equalTo(1L));
+        assertThat(resourceIdsWithEnvoyLabels.getContent().get(0).getResourceId(), equalTo("development:0"));
     }
 
     @Test
@@ -278,10 +278,10 @@ public class ResourceManagementTest {
         labelsToQuery.put("os", "DARWIN");
         labelsToQuery.put("environment", "localdev");
         labelsToQuery.put("arch", "X86_64");
-        final List<Resource> resourceIdsWithEnvoyLabels = resourceManagement
-                .getResourcesFromLabels(labelsToQuery, "tenant-1");
+        final Page<Resource> resourceIdsWithEnvoyLabels = resourceManagement
+                .getResourcesFromLabels(labelsToQuery, "tenant-1", Pageable.unpaged());
 
-        assertEquals(0, resourceIdsWithEnvoyLabels.size());
+        assertEquals(0L, resourceIdsWithEnvoyLabels.getTotalElements());
 
     }
 
@@ -570,9 +570,9 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(1, resources.size());
-        assertEquals(metadata, resources.get(0).getMetadata());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements());
+        assertEquals(metadata, resources.getContent().get(0).getMetadata());
         assertNotNull(resources);
     }
 
@@ -588,10 +588,10 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         resourceManagement.createResource(tenantId2, create);
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
-        assertEquals(create.getResourceId(), resources.get(0).getResourceId());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
     }
 
     @Test
@@ -606,11 +606,11 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
-        assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(labels, resources.get(0).getLabels());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
+        assertEquals(labels, resources.getContent().get(0).getLabels());
     }
 
     @Test
@@ -629,8 +629,8 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(0, resources.size());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(0L, resources.getTotalElements());
     }
 
     @Test
@@ -650,11 +650,11 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
-        assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(resourceLabels, resources.get(0).getLabels());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
+        assertEquals(resourceLabels, resources.getContent().get(0).getLabels());
     }
 
     @Test
@@ -674,8 +674,8 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(0, resources.size());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(0L, resources.getTotalElements());
     }
 
     @Test
@@ -696,8 +696,8 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId);
-        assertEquals(0, resources.size());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        assertEquals(0L, resources.getTotalElements());
     }
 
     @Test
@@ -712,10 +712,10 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId);
-        assertThat(resources, hasSize(1));
-        assertThat(resources.get(0).getTenantId(), equalTo(tenantId));
-        assertThat(resources.get(0).getResourceId(), equalTo(create.getResourceId()));
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId, Pageable.unpaged());
+        assertThat(resources.getTotalElements(), equalTo(1L));
+        assertThat(resources.getContent().get(0).getTenantId(), equalTo(tenantId));
+        assertThat(resources.getContent().get(0).getResourceId(), equalTo(create.getResourceId()));
     }
 
     @Test
@@ -737,10 +737,12 @@ public class ResourceManagementTest {
         resourceRepository.saveAll(resourcesToSave);
         entityManager.flush();
 
-        List<Resource> resources = resourceManagement.getResourcesFromLabels(
-            Collections.singletonMap("os", "linux"), "testGetResourcesFromLabels_multipleMatches");
-        assertThat(resources, hasSize(10));
-        assertThat(resources.get(0).getTenantId(), equalTo("testGetResourcesFromLabels_multipleMatches"));
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(
+            Collections.singletonMap("os", "linux"),
+            "testGetResourcesFromLabels_multipleMatches",
+            Pageable.unpaged());
+        assertThat(resources.getTotalElements(), equalTo(10L));
+        assertThat(resources.getContent().get(0).getTenantId(), equalTo("testGetResourcesFromLabels_multipleMatches"));
     }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -62,6 +62,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -139,7 +140,7 @@ public class ResourceApiControllerTest {
     int numberOfResources = 20;
     // Use the APIs default Pageable settings
     int page = 0;
-    int pageSize = 100;
+    int pageSize = 20;
     List<Resource> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
       resources.add(podamFactory.manufacturePojo(Resource.class));
@@ -165,7 +166,7 @@ public class ResourceApiControllerTest {
         .andExpect(jsonPath("$.totalPages", equalTo(1)))
         .andExpect(jsonPath("$.totalElements", equalTo(numberOfResources)));
 
-    verify(resourceManagement).getResources(tenantId, PageRequest.of(0, 100));
+    verify(resourceManagement).getResources(tenantId, PageRequest.of(0, 20));
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -314,10 +315,10 @@ public class ResourceApiControllerTest {
 
   @Test
   public void testGetAll() throws Exception {
-    int numberOfResources = 20;
+    int numberOfResources = 17;
     // Use the APIs default Pageable settings
     int page = 0;
-    int pageSize = 100;
+    int pageSize = 20;
     List<Resource> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
       resources.add(podamFactory.manufacturePojo(Resource.class));
@@ -332,7 +333,7 @@ public class ResourceApiControllerTest {
     when(resourceManagement.getAllResources(any()))
         .thenReturn(pageOfResources);
 
-    mockMvc.perform(get("/api/resources")
+    mockMvc.perform(get("/api/admin/resources")
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content()
@@ -341,7 +342,7 @@ public class ResourceApiControllerTest {
         .andExpect(jsonPath("$.totalPages", equalTo(1)))
         .andExpect(jsonPath("$.totalElements", equalTo(numberOfResources)));
 
-    verify(resourceManagement).getAllResources(PageRequest.of(0, 100));
+    verify(resourceManagement).getAllResources(PageRequest.of(0, 20));
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -386,8 +387,8 @@ public class ResourceApiControllerTest {
         .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any()))
-        .thenReturn(expectedResources);
+    when(resourceManagement.getResourcesFromLabels(any(), any(), any()))
+        .thenReturn(new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size()));
 
     mockMvc.perform(get(
         "/api/tenant/{tenantId}/resourceLabels?env=prod",
@@ -397,7 +398,8 @@ public class ResourceApiControllerTest {
 
     verify(resourceManagement).getResourcesFromLabels(
         Collections.singletonMap("env", "prod"),
-        "t-1"
+        "t-1",
+        PageRequest.of(0, 20)
     );
 
     verifyNoMoreInteractions(resourceManagement);


### PR DESCRIPTION
# What

Basically the same as https://github.com/racker/salus-telemetry-monitor-management/pull/47

Updates the monitor and zone apis so that pagination params can be specified in the request and handled correctly.

Also fixes the indentation of some files... seeing how github is interpreting them, I now wish I didn't click that button during these changes.  It makes this PR more painful to review than it should have been.

Reviewing the test changes might be the easiest way to see the differences.

# How

 * Mostly this was just converting the use of Lists over to Pages
 * The ApiController no longer implements to API interface.
 * Fixed some urls - e.g. prepend with `/admin`
 * Updated responses to be `PagedContent`
 * I did remove some methods that weren't used.
   * `getExpectedEnvoys` etc. I think these were provided to satisfy the interface
 * Introduced `getPagedResults` for the labels query - same as over in monitor-mgmt

## How to test

Run tests.  I also did some manual validation via the direct apis and via the public / admin api.

# Why

It finalizes our APIs a little more and will make them all work in a consistent manner.

