### PR TITLE
Declare JPA indexing of resource labels table

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/resource_management/entities/Resource.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.resource_management.entities;
@@ -32,6 +30,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -74,7 +73,13 @@ public class Resource implements Serializable {
      */
     @ValidLabelKeys
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name="resource_labels", joinColumns = @JoinColumn(name="id"))
+    @CollectionTable(
+        name="resource_labels",
+        joinColumns = @JoinColumn(name="id"),
+        indexes = {
+            @Index(columnList = "id,labels_key,labels")
+        }
+    )
     Map<String,String> labels;
 
     /**


### PR DESCRIPTION
# What

It dawned on me that the resource labels table created by JPA/Hibernate may not have indexes declared on it by default and indeed that was the case. With the annotation change in this PR I now see the index being created:

```
Hibernate: create index IDXsfyp9clv4p78phb65j12dp8av on resource_labels (id, labels_key, labels)
```

## How to test

Existing unit tests. Ideally we would have some kind of benchmarking/stress test setup where could have seen a before and after performance improvement.