### PR TITLE
Limit salus-test maven dependency to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-test</artifactId>
       <version>0.1.0-SNAPSHOT</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
# What

While using this pom for a new module I noticed the `salus-test` dependency needed to be limited to test scope.