### PR TITLE
Add endpoint to get all tenants with at least one resource

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/entities/Resource.java
+++ b/src/main/java/com/rackspace/salus/resource_management/entities/Resource.java
@@ -58,7 +58,9 @@ import org.hibernate.validator.constraints.NotBlank;
     @NamedQuery(name = "Resource.getDistinctLabels",
     query = "select distinct entry(r.labels) from Resource r where r.tenantId = :tenantId"),
     @NamedQuery(name = "Resource.getMetadata",
-    query = "select r.metadata from Resource r where r.tenantId = :tenantId")
+    query = "select r.metadata from Resource r where r.tenantId = :tenantId"),
+    @NamedQuery(name = "Resource.getAllDistinctTenants",
+    query = "select distinct r.tenantId from Resource r")
 })
 @TypeDef(name = "json", typeClass = JsonStringType.class)
 @Data

--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 
@@ -37,4 +38,7 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
   Optional<Resource> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
   List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
+
+  @Query("select distinct r.tenantId from Resource r")
+  List<String> findAllDistinctTenants();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -38,7 +38,4 @@ public interface ResourceRepository extends PagingAndSortingRepository<Resource,
   Optional<Resource> findByTenantIdAndResourceId(String tenantId, String resourceId);
 
   List<Resource> findAllByTenantIdAndPresenceMonitoringEnabled(String tenantId, boolean presenceMonitoringEnabled);
-
-  @Query("select distinct r.tenantId from Resource r")
-  List<String> findAllDistinctTenants();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
+++ b/src/main/java/com/rackspace/salus/resource_management/repositories/ResourceRepository.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -512,4 +512,12 @@ public class ResourceManagement {
   public Collection<String> getLabelNamespaces() {
     return LabelNamespaces.getNamespaces();
   }
+
+  /**
+   * Gets a list of all tenants that have at least one resource.
+   * @return A list of tenant ids.
+   */
+  public List<String> getAllDistinctTenantIds() {
+    return resourceRepository.findAllDistinctTenants();
+  }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -518,6 +518,8 @@ public class ResourceManagement {
    * @return A list of tenant ids.
    */
   public List<String> getAllDistinctTenantIds() {
-    return resourceRepository.findAllDistinctTenants();
+    return entityManager
+        .createNamedQuery("Resource.getAllDistinctTenants", String.class)
+        .getResultList();
   }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -36,4 +36,6 @@ public interface ResourceApi {
                                         Map<String, String> labels);
 
   List<ResourceDTO> getExpectedEnvoys();
+
+  List<String> getAllDistinctTenantIds();
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -67,6 +67,9 @@ public class ResourceApiClient implements ResourceApi {
   private static final ParameterizedTypeReference<PagedContent<ResourceDTO>> PAGE_OF_RESOURCE =
       new ParameterizedTypeReference<PagedContent<ResourceDTO>>() {};
 
+  private static final ParameterizedTypeReference<List<String>> LIST_OF_STRING =
+      new ParameterizedTypeReference<List<String>>() {};
+
   private ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
   private static final String SSEHdr = "data:";
@@ -134,5 +137,22 @@ public class ResourceApiClient implements ResourceApi {
       return response;
     });
     return resources;
+  }
+
+  @Override
+  public List<String> getAllDistinctTenantIds() {
+    String uriString = UriComponentsBuilder
+        .fromUriString("/api/admin/tenants")
+        .build()
+        .toUriString();
+
+    ResponseEntity<List<String>> resp = restTemplate.exchange(
+        uriString,
+        HttpMethod.GET,
+        null,
+        LIST_OF_STRING
+    );
+
+    return resp.getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -181,4 +181,11 @@ public class ResourceApiController {
   public Collection<String> getLabelNamespaces(@PathVariable String tenantId) {
     return resourceManagement.getLabelNamespaces();
   }
+
+  @GetMapping("/admin/tenants")
+  @ApiOperation("Gets a list of all tenant ids")
+  @JsonView(View.Admin.class)
+  public List<String> getAllDistinctTenantIds() {
+    return resourceManagement.getAllDistinctTenantIds();
+  }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -18,9 +18,11 @@ package com.rackspace.salus.resource_management;
 
 import static com.rackspace.salus.telemetry.model.LabelNamespaces.AGENT;
 import static com.rackspace.salus.telemetry.model.LabelNamespaces.applyNamespace;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -43,6 +45,7 @@ import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.resource_management.entities.Resource;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -826,5 +829,20 @@ public class ResourceManagementTest {
                 .setMetadata(metadata)
                 .setPresenceMonitoringEnabled(true)
         );
+    }
+
+    @Test
+    public void testGetAllDistinctTenants() {
+        final List<Resource> resources = podamFactory.manufacturePojo(ArrayList.class, Resource.class);
+        resourceRepository.saveAll(resources);
+
+        List<String> expectedIds = resources.stream().map(Resource::getTenantId).collect(Collectors.toList());
+        expectedIds.add(TENANT); // include the default resource's tenant
+
+        List<String> tenantIds = resourceManagement.getAllDistinctTenantIds();
+
+        assertThat(tenantIds, notNullValue());
+        assertThat(tenantIds, hasSize(expectedIds.size()));
+        assertThat(tenantIds, containsInAnyOrder(expectedIds.toArray()));
     }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.model.PagedContent;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -135,5 +136,20 @@ public class ResourceApiClientTest {
 
     assertThat(resources.size(), equalTo(expectedResources.size()));
     assertThat(resources, equalTo(expectedResources));
+  }
+
+  @Test
+  public void testGetAllDistinctTenants() throws JsonProcessingException {
+    final List<String> tenantIds = podamFactory.manufacturePojo(ArrayList.class, String.class);
+
+    mockServer.expect(requestTo("/api/admin/tenants"))
+        .andRespond(withSuccess(
+            objectMapper.writeValueAsString(tenantIds), MediaType.APPLICATION_JSON
+        ));
+
+    final List<String> result = resourceApiClient
+        .getAllDistinctTenantIds();
+
+    assertThat(result, equalTo(tenantIds));
   }
 }

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -466,4 +466,21 @@ public class ResourceApiControllerTest {
 
     verifyNoMoreInteractions(resourceManagement);
   }
+
+  @Test
+  public void testGetAllDistinctTenants() throws Exception {
+    final List<String> tenantIds = podamFactory.manufacturePojo(ArrayList.class, String.class);
+    when(resourceManagement.getAllDistinctTenantIds())
+        .thenReturn(tenantIds);
+
+    mockMvc.perform(get("/api/admin/tenants")
+        .accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(
+            content().json(objectMapper.writeValueAsString(tenantIds)));
+
+    verify(resourceManagement).getAllDistinctTenantIds();
+    verifyNoMoreInteractions(resourceManagement);
+  }
 }


### PR DESCRIPTION
# What

Returns all distinct tenant ids that the resource management service is aware of.

# How

Simple db query + adds api endpoints + tests.

## How to test

Run tests!

# Why

Policy Management will query this when a policy change occurs and then send out a single `PolicyEvent` for each tenant.  This is so the monitor management service (and other in future) will be able to consume these one at a time, deciding what action needs to happen for an individual tenant, rather than being overloaded by trying to handle all tenants at once. 
