### PR TITLE
handling jdbc exceptions and kafka exceptions through the RestExcepti…

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
@@ -16,10 +16,12 @@
 
 package com.rackspace.salus.resource_management.services;
 
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -46,6 +48,13 @@ public class KafkaEgress {
 
         log.debug("Sending event={} on topic={}", event, topic);
         final String key = KafkaMessageKeyBuilder.buildMessageKey(event);
-        kafkaTemplate.send(topic, key, event);
+
+        try {
+            kafkaTemplate.send(topic, key, event).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeKafkaException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeKafkaException(e);
+        }
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/KafkaEgress.java
@@ -51,9 +51,7 @@ public class KafkaEgress {
 
         try {
             kafkaTemplate.send(topic, key, event).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeKafkaException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException|ExecutionException e) {
             throw new RuntimeKafkaException(e);
         }
     }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
@@ -16,10 +16,14 @@
 
 package com.rackspace.salus.resource_management.web.controller;
 
+import com.rackspace.salus.common.errors.ResponseMessages;
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.web.AbstractRestExceptionHandler;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import java.util.concurrent.ExecutionException;
 import javax.servlet.http.HttpServletRequest;
+import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
@@ -51,5 +55,17 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
     public ResponseEntity<?> handleAlreadyExists(
         HttpServletRequest request) {
         return respondWith(request, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @ExceptionHandler({JDBCException.class})
+    public ResponseEntity<?> handleJDBCException(
+        HttpServletRequest request) {
+        return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+    }
+
+    @ExceptionHandler({RuntimeKafkaException.class})
+    public ResponseEntity<?> handleKafkaExceptions(
+        HttpServletRequest request) {
+        return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
@@ -60,12 +60,12 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
     @ExceptionHandler({JDBCException.class})
     public ResponseEntity<?> handleJDBCException(
         HttpServletRequest request) {
-        return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+        return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
     }
 
     @ExceptionHandler({RuntimeKafkaException.class})
     public ResponseEntity<?> handleKafkaExceptions(
         HttpServletRequest request) {
-        return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
+        return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
     }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-433

# What

This PR is trying to catch the error when the API nodes are up but a service behind the API node isn't. 

# How

I am catching the particular error that gets thrown when another service isn't running. 

## How to test

Start this service after starting all of the docker containers. 
After this has started shut down mysql.
Send a creation request in.
Bring mysql back up and shut down kafka.
send the same creation request.

# Why

For unknown reasons Spring Boot doesn't seem to appreciate using the configuration options for not including the exception or the stack trace.

Instead I decided to utilize the pattern we are already using for catching exceptions and responding with HTTP status codes to give a friendly message.