### PR TITLE
Logical OR processing for resources

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.resource_management.web.client;
 
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +33,8 @@ public interface ResourceApi {
                            String resourceId);
 
   List<ResourceDTO> getResourcesWithLabels(String tenantId,
-                                        Map<String, String> labels);
+                                        Map<String, String> labels,
+                                        LabelSelectorMethod labelSelector);
 
   List<ResourceDTO> getExpectedEnvoys();
 

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.resource_management.web.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -98,13 +99,16 @@ public class ResourceApiClient implements ResourceApi {
   }
 
   @Override
-  public List<ResourceDTO> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
-    String endpoint = "/api/tenant/{tenantId}/resources-by-label/AND";
+  public List<ResourceDTO> getResourcesWithLabels(String tenantId, Map<String, String> labels, LabelSelectorMethod labelSelector) {
+    String endpoint = "/api/tenant/{tenantId}/resources-by-label/{logicalOperator}";
     UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
     for (Map.Entry<String, String> e : labels.entrySet()) {
       uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
     }
-    String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
+    //String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
+    Object[] items = {tenantId, labelSelector};
+
+    String uriString = uriComponentsBuilder.buildAndExpand(items).toUriString();
     ResponseEntity<PagedContent<ResourceDTO>> resp = restTemplate.exchange(
         uriString,
         HttpMethod.GET,

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -105,10 +105,8 @@ public class ResourceApiClient implements ResourceApi {
     for (Map.Entry<String, String> e : labels.entrySet()) {
       uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
     }
-    //String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
-    Object[] items = {tenantId, labelSelector};
 
-    String uriString = uriComponentsBuilder.buildAndExpand(items).toUriString();
+    String uriString = uriComponentsBuilder.buildAndExpand(tenantId, labelSelector).toUriString();
     ResponseEntity<PagedContent<ResourceDTO>> resp = restTemplate.exchange(
         uriString,
         HttpMethod.GET,

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -99,7 +99,7 @@ public class ResourceApiClient implements ResourceApi {
 
   @Override
   public List<ResourceDTO> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
-    String endpoint = "/api/tenant/{tenantId}/resources-by-label";
+    String endpoint = "/api/tenant/{tenantId}/resources-by-label/AND";
     UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
     for (Map.Entry<String, String> e : labels.entrySet()) {
       uriComponentsBuilder.queryParam(e.getKey(), e.getValue());

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -152,11 +152,11 @@ public class ResourceApiController {
     resourceManagement.removeResource(tenantId, resourceId);
   }
 
-  @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperation}")
+  @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperator}")
   @JsonView(View.Public.class)
   public PagedContent<ResourceDTO> getResourcesWithLabels(@PathVariable String tenantId,
-      @RequestParam Map<String, String> labels, @PathVariable String logicalOperation, Pageable pageable) {
-    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.valueOf(logicalOperation), pageable)
+      @RequestParam Map<String, String> labels, @PathVariable String logicalOperator, Pageable pageable) {
+    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.valueOf(logicalOperator), pageable)
         .map(ResourceDTO::new));
   }
 

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -22,6 +22,7 @@ import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.model.PagedContent;
@@ -151,11 +152,11 @@ public class ResourceApiController {
     resourceManagement.removeResource(tenantId, resourceId);
   }
 
-  @GetMapping("/tenant/{tenantId}/resources-by-label")
+  @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperation}")
   @JsonView(View.Public.class)
   public PagedContent<ResourceDTO> getResourcesWithLabels(@PathVariable String tenantId,
-      @RequestParam Map<String, String> labels, Pageable pageable) {
-    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, pageable)
+      @RequestParam Map<String, String> labels, @PathVariable String logicalOperation, Pageable pageable) {
+    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.valueOf(logicalOperation), pageable)
         .map(ResourceDTO::new));
   }
 

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -155,8 +155,8 @@ public class ResourceApiController {
   @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperator}")
   @JsonView(View.Public.class)
   public PagedContent<ResourceDTO> getResourcesWithLabels(@PathVariable String tenantId,
-      @RequestParam Map<String, String> labels, @PathVariable String logicalOperator, Pageable pageable) {
-    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.valueOf(logicalOperator), pageable)
+      @RequestParam Map<String, String> labels, @PathVariable LabelSelectorMethod logicalOperator, Pageable pageable) {
+    return PagedContent.fromPage(resourceManagement.getResourcesFromLabels(labels, tenantId, logicalOperator, pageable)
         .map(ResourceDTO::new));
   }
 

--- a/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
@@ -21,7 +21,7 @@ WHERE
             FROM resource_labels
             WHERE %s
             GROUP BY id
-            HAVING COUNT(*) = :i
+            HAVING COUNT(*) >= 1
          )
    )
 GROUP BY resources.id

--- a/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
@@ -6,21 +6,21 @@ WHERE
    resources.id = rl.id
    AND resources.id IN
    (
-      SELECT id
-      FROM resource_labels
+      SELECT inner_rl.id
+      FROM resource_labels AS inner_rl
       WHERE
          id IN
          (
-            SELECT id
-            FROM resources
-            WHERE tenant_id = :tenantId
+            SELECT inner_resources.id
+            FROM resources AS inner_resources
+            WHERE inner_resources.tenant_id = :tenantId
          )
          AND resources.id IN
          (
-            SELECT id
-            FROM resource_labels
+            SELECT most_inner_rl.id
+            FROM resource_labels AS most_inner_rl
             WHERE %s
-            GROUP BY id
+            GROUP BY most_inner_rl.id
             HAVING COUNT(*) >= 1
          )
    )

--- a/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
@@ -9,7 +9,7 @@ WHERE
       SELECT inner_rl.id
       FROM resource_labels AS inner_rl
       WHERE
-         id IN
+         inner_rl.id IN
          (
             SELECT inner_resources.id
             FROM resources AS inner_resources

--- a/src/main/resources/sql-queries/resource_label_matching_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_query.sql
@@ -6,21 +6,21 @@ WHERE
    resources.id = rl.id
    AND resources.id IN
    (
-      SELECT id
-      FROM resource_labels
+      SELECT inner_rl.id
+      FROM resource_labels AS inner_rl
       WHERE
-         id IN
+         inner_rl.id IN
          (
-            SELECT id
-            FROM resources
-            WHERE tenant_id = :tenantId
+            SELECT inner_resources.id
+            FROM resources AS inner_resources
+            WHERE inner_resources.tenant_id = :tenantId
          )
          AND resources.id IN
          (
-            SELECT id
-            FROM resource_labels
+            SELECT most_inner_rl.id
+            FROM resource_labels AS most_inner_rl
             WHERE %s
-            GROUP BY id
+            GROUP BY most_inner_rl.id
             HAVING COUNT(*) = :i
          )
    )

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.google.common.collect.Maps;
 import com.rackspace.salus.resource_management.config.DatabaseConfig;
 import com.rackspace.salus.resource_management.config.ResourceManagementProperties;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import com.rackspace.salus.resource_management.services.KafkaEgress;
 import com.rackspace.salus.resource_management.services.ResourceManagement;
@@ -259,7 +260,7 @@ public class ResourceManagementTest {
         final Map<String, String> labelsToQuery = new HashMap<>();
         labelsToQuery.put("os", "DARWIN");
         final Page<Resource> resourceIdsWithEnvoyLabels = resourceManagement
-            .getResourcesFromLabels(labelsToQuery, "tenant-1", Pageable.unpaged());
+            .getResourcesFromLabels(labelsToQuery, "tenant-1", LabelSelectorMethod.AND, Pageable.unpaged());
 
         assertThat(resourceIdsWithEnvoyLabels.getTotalElements(), equalTo(1L));
         assertThat(resourceIdsWithEnvoyLabels.getContent().get(0).getResourceId(), equalTo("development:0"));
@@ -287,7 +288,7 @@ public class ResourceManagementTest {
         labelsToQuery.put("environment", "localdev");
         labelsToQuery.put("arch", "X86_64");
         final Page<Resource> resourceIdsWithEnvoyLabels = resourceManagement
-                .getResourcesFromLabels(labelsToQuery, "tenant-1", Pageable.unpaged());
+                .getResourcesFromLabels(labelsToQuery, "tenant-1", LabelSelectorMethod.AND, Pageable.unpaged());
 
         assertEquals(0L, resourceIdsWithEnvoyLabels.getTotalElements());
 
@@ -578,7 +579,7 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(1L, resources.getTotalElements());
         assertEquals(metadata, resources.getContent().get(0).getMetadata());
         assertNotNull(resources);
@@ -596,7 +597,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         resourceManagement.createResource(tenantId2, create);
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
         assertEquals(tenantId, resources.getContent().get(0).getTenantId());
         assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
@@ -614,7 +615,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
         assertEquals(tenantId, resources.getContent().get(0).getTenantId());
         assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
@@ -637,7 +638,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(0L, resources.getTotalElements());
     }
 
@@ -657,7 +658,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
         assertEquals(tenantId, resources.getContent().get(0).getTenantId());
         assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
@@ -680,7 +681,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(0L, resources.getTotalElements());
     }
 
@@ -701,7 +702,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertEquals(0L, resources.getTotalElements());
     }
 
@@ -717,7 +718,7 @@ public class ResourceManagementTest {
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId, Pageable.unpaged());
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
         assertThat(resources.getTotalElements(), equalTo(1L));
         assertThat(resources.getContent().get(0).getTenantId(), equalTo(tenantId));
         assertThat(resources.getContent().get(0).getResourceId(), equalTo(create.getResourceId()));
@@ -745,6 +746,7 @@ public class ResourceManagementTest {
         Page<Resource> resources = resourceManagement.getResourcesFromLabels(
             Collections.singletonMap("os", "linux"),
             "testGetResourcesFromLabels_multipleMatches",
+            LabelSelectorMethod.AND,
             Pageable.unpaged());
         assertThat(resources.getTotalElements(), equalTo(10L));
         assertThat(resources.getContent().get(0).getTenantId(), equalTo("testGetResourcesFromLabels_multipleMatches"));

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -695,7 +695,7 @@ public class ResourceManagementTest {
         resourceLabels.put("architecture", "x86");
         final Map<String, String> labels = new HashMap<>();
         labels.put("os", "DARWIN");
-        labels.put("env", "test");
+        labels.put("env", "prod");
 
         ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
         create.setLabels(resourceLabels);

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -112,7 +113,7 @@ public class ResourceApiClientTest {
         ));
 
     final List<ResourceDTO> resources = resourceApiClient
-        .getResourcesWithLabels("t-1", Collections.singletonMap("env", "prod"));
+        .getResourcesWithLabels("t-1", Collections.singletonMap("env", "prod"), LabelSelectorMethod.AND);
 
     assertThat(resources, equalTo(expectedResources));
   }

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -106,7 +106,7 @@ public class ResourceApiClientTest {
         new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size())
     );
 
-    mockServer.expect(requestTo("/api/tenant/t-1/resources-by-label?env=prod"))
+    mockServer.expect(requestTo("/api/tenant/t-1/resources-by-label/AND?env=prod"))
         .andRespond(withSuccess(
             objectMapper.writeValueAsString(result), MediaType.APPLICATION_JSON
         ));

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -45,6 +45,7 @@ import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -385,11 +386,11 @@ public class ResourceApiControllerTest {
         .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any(), any()))
+    when(resourceManagement.getResourcesFromLabels(any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size()));
 
     mockMvc.perform(get(
-        "/api/tenant/{tenantId}/resources-by-label?env=prod",
+        "/api/tenant/{tenantId}/resources-by-label/AND?env=prod",
         "t-1"
     ).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
@@ -397,6 +398,7 @@ public class ResourceApiControllerTest {
     verify(resourceManagement).getResourcesFromLabels(
         Collections.singletonMap("env", "prod"),
         "t-1",
+        LabelSelectorMethod.AND,
         PageRequest.of(0, 20)
     );
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-606

# What

Support logical OR as well as logical AND processing for matching labels. The label matching in here is from monitors to resources so we dont need to combine the results together since the monitor will tell us what sort of processing we need to do. 

# How

I duplicated the AND query and modified it for handling OR processing. 

## How to test

Run the unit tests. The functions that are testing this end in "UsingOr"

# Why

We considered handling this in a hybrid approach through JPA or Hibernate. Neither of those places seemed to have a good way of querying map values. 

There was also a consideration for doing this through a hybrid approach but that would still require the writing of the OR based query and then handling the rest of the processing server side. Since we already have the AND query it seems more logical to me to just handle this all at query time.

