### PR TITLE
The non-deploy build config should just use the verify goal

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,12 +27,12 @@ steps:
     - name: user.home
       path: /root
 
-  - id: DEPLOY
+  - id: VERIFY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
     volumes:
-    - name: user.home
-      path: /root
+      - name: user.home
+        path: /root
 
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,18 +37,19 @@ steps:
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE
     waitFor:
-    - DEPLOY
+      - VERIFY
     name: gcr.io/cloud-builders/gsutil
     dir: /root
     entrypoint: bash
     # Caches the local Maven repository.
     args:
-    - -c
-    - |
-      set -ex
-      tar -czf /tmp/m2-cache.tar.gz .m2 &&
-      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+      - -c
+      - |
+        set -ex
+        tar -czf /tmp/m2-cache.tar.gz .m2 &&
+        gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
     volumes:
-    - name: user.home
-      path: /root
+      - name: user.home
+        path: /root
+
 

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
@@ -17,11 +17,9 @@
 package com.rackspace.salus.resource_management.web.controller;
 
 import com.rackspace.salus.common.errors.ResponseMessages;
-import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.web.AbstractRestExceptionHandler;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import java.util.concurrent.ExecutionException;
 import javax.servlet.http.HttpServletRequest;
 import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,12 +35,6 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
     @Autowired
     public RestExceptionHandler(ErrorAttributes errorAttributes) {
         super(errorAttributes);
-    }
-
-    @ExceptionHandler({IllegalArgumentException.class})
-    public ResponseEntity<?> handleBadRequest(
-        HttpServletRequest request) {
-        return respondWith(request, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({NotFoundException.class})
@@ -61,11 +53,5 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
     public ResponseEntity<?> handleJDBCException(
         HttpServletRequest request) {
         return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
-    }
-
-    @ExceptionHandler({RuntimeKafkaException.class})
-    public ResponseEntity<?> handleKafkaExceptions(
-        HttpServletRequest request) {
-        return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
     }
 }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/RestExceptionHandler.java
@@ -39,19 +39,22 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
 
     @ExceptionHandler({NotFoundException.class})
     public ResponseEntity<?> handleNotFound(
-        HttpServletRequest request) {
+        HttpServletRequest request, Exception e) {
+        logRequestFailure(request, e);
         return respondWith(request, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler({AlreadyExistsException.class})
     public ResponseEntity<?> handleAlreadyExists(
-        HttpServletRequest request) {
+        HttpServletRequest request, Exception e) {
+        logRequestFailure(request, e);
         return respondWith(request, HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @ExceptionHandler({JDBCException.class})
     public ResponseEntity<?> handleJDBCException(
-        HttpServletRequest request) {
+        HttpServletRequest request, Exception e) {
+        logRequestFailure(request, e);
         return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
     }
 }


### PR DESCRIPTION
# What

I noticed monitor-management builds were failing sometimes on symbol mismatches from resource-management changes that were still in active PR branches. For example

https://console.cloud.google.com/cloud-build/builds/be12c37d-fc01-4971-b7f1-c45dd44feb15?project=salus-220516&authuser=1&organizationId=767495606862

# How

Fixed the non-deploy build config to match our others.

## How to test

Do a non-master/tag GCP build.