### PR TITLE
Add create endpoint to api client

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -16,10 +16,12 @@
 
 package com.rackspace.salus.resource_management.web.client;
 
+import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.util.List;
 import java.util.Map;
+import org.springframework.util.MultiValueMap;
 
 /**
  * This interface declares a subset of internal REST API calls exposed by the Resource Management
@@ -39,4 +41,6 @@ public interface ResourceApi {
   List<ResourceDTO> getExpectedEnvoys();
 
   List<String> getAllDistinctTenantIds();
+
+  ResourceDTO createResource(String tenantId, ResourceCreate create, MultiValueMap<String, String> headers);
 }


### PR DESCRIPTION
# What

Adds a create endpoint to the api client.

# How

I included `MultiValueMap<String, String> headers` so that this can be used against the public api and provide an `x-auth-token`.  I spoke to @itzg briefly about that before and if the need arises we might want to add that to all the api client methods (or at least any we add from here on) so that it is more of a comprehensive client that can be used for multiple purposes and not just internal service-to-service requests.

# Why

I'm utilizing this client in the migration app.