### PR TITLE
Fixed resource management label query and added extra tests

### DIFF
--- a/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_OR_query.sql
@@ -1,28 +1,13 @@
-SELECT
-   resources.id as id
-FROM
-   resources JOIN resource_labels AS rl
-WHERE
-   resources.id = rl.id
-   AND resources.id IN
-   (
-      SELECT inner_rl.id
-      FROM resource_labels AS inner_rl
-      WHERE
-         inner_rl.id IN
-         (
-            SELECT inner_resources.id
-            FROM resources AS inner_resources
-            WHERE inner_resources.tenant_id = :tenantId
-         )
-         AND resources.id IN
-         (
-            SELECT most_inner_rl.id
-            FROM resource_labels AS most_inner_rl
-            WHERE %s
-            GROUP BY most_inner_rl.id
-            HAVING COUNT(*) >= 1
-         )
+SELECT  resources.id as id
+FROM    resources JOIN resource_labels AS rl
+WHERE   resources.id = rl.id
+AND     resources.tenant_id = :tenantId
+AND     resources.id IN (
+    SELECT      most_inner_rl.id
+    FROM        resource_labels AS most_inner_rl
+    WHERE       %s
+    GROUP BY    most_inner_rl.id
+    HAVING COUNT(*) >= 1
    )
 GROUP BY resources.id
 ORDER BY resources.id

--- a/src/main/resources/sql-queries/resource_label_matching_query.sql
+++ b/src/main/resources/sql-queries/resource_label_matching_query.sql
@@ -1,28 +1,13 @@
-SELECT
-   resources.id as id
-FROM
-   resources JOIN resource_labels AS rl
-WHERE
-   resources.id = rl.id
-   AND resources.id IN
-   (
-      SELECT inner_rl.id
-      FROM resource_labels AS inner_rl
-      WHERE
-         inner_rl.id IN
-         (
-            SELECT inner_resources.id
-            FROM resources AS inner_resources
-            WHERE inner_resources.tenant_id = :tenantId
-         )
-         AND resources.id IN
-         (
-            SELECT most_inner_rl.id
-            FROM resource_labels AS most_inner_rl
-            WHERE %s
-            GROUP BY most_inner_rl.id
-            HAVING COUNT(*) = :i
-         )
+SELECT  resources.id as id
+FROM    resources JOIN resource_labels AS rl
+WHERE   resources.id = rl.id
+AND     resources.tenant_id = :tenantId
+AND     resources.id IN (
+    SELECT      most_inner_rl.id
+    FROM        resource_labels AS most_inner_rl
+    WHERE       %s
+    GROUP BY    most_inner_rl.id
+    HAVING COUNT(*) = :i
    )
 GROUP BY resources.id
 ORDER BY resources.id

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -698,6 +698,7 @@ public class ResourceManagementTest {
         assertThat(resourceIds, containsInAnyOrder(create.getResourceId(), create2.getResourceId()));
     }
 
+    //This test is supposed to make sure that when matching resources we are still only returning the tenants requested
     public void testMatchResourceWithNoLabelsAsOrRequestOnlyReturnsTenant() {
         final Map<String, String> labels = new HashMap<>();
         labels.put("os", "DARWIN");

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -663,6 +663,50 @@ public class ResourceManagementTest {
     }
 
     @Test
+    public void testMatchResourceWithNoLabelsAsOrRequest() {
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("os", "DARWIN");
+        labels.put("env", "test");
+
+        final Map<String, String> matchLabels = new HashMap<>();
+        labels.put("os", "DARWIN");
+
+        ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
+        create.setLabels(Collections.emptyMap());
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        resourceManagement.createResource(tenantId, create);
+        entityManager.flush();
+
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(matchLabels, tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
+        assertEquals(Collections.emptyMap(), resources.getContent().get(0).getLabels());
+    }
+
+    public void testMatchResourceWithNoLabelsAsOrRequestOnlyReturnsTenant() {
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("os", "DARWIN");
+        labels.put("env", "test");
+
+        final Map<String, String> matchLabels = new HashMap<>();
+        labels.put("os", "DARWIN");
+
+        ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
+        create.setLabels(Collections.emptyMap());
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        resourceManagement.createResource(tenantId, create);
+        resourceManagement.createResource(RandomStringUtils.randomAlphanumeric(10), create);
+        entityManager.flush();
+
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(matchLabels, tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
+        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
+        assertEquals(labels, resources.getContent().get(0).getLabels());
+    }
+
+    @Test
     public void testFailedMatchResourceWithMultipleLabels() {
         final Map<String, String> resourceLabels = new HashMap<>();
         resourceLabels.put("os", "DARWIN");

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -662,24 +662,35 @@ public class ResourceManagementTest {
         assertEquals(labels, resources.getContent().get(0).getLabels());
     }
 
+    /**
+     * Make sure that when supplied with a emptyMap collection that we return resources with no labels
+     * as well as any resources for that tenant
+     */
     @Test
-    public void testMatchResourceWithNoLabelsAsOrRequest() {
-        final Map<String, String> labels = new HashMap<>();
-        labels.put("os", "DARWIN");
-        labels.put("env", "test");
-
-        final Map<String, String> matchLabels = new HashMap<>();
-        labels.put("os", "DARWIN");
+    public void testMatchResourcesWithEmptyLabels() {
 
         ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
         create.setLabels(Collections.emptyMap());
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         resourceManagement.createResource(tenantId, create);
+
+
+
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("os", "DARWIN");
+        labels.put("env", "test");
+
+        ResourceCreate create2 = podamFactory.manufacturePojo(ResourceCreate.class);
+        create.setLabels(labels);
+        resourceManagement.createResource(tenantId, create2);
+
+
         entityManager.flush();
 
-        Page<Resource> resources = resourceManagement.getResourcesFromLabels(matchLabels, tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
-        assertEquals(1L, resources.getTotalElements()); //make sure we only returned the one value
+        Page<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
+        assertEquals(2L, resources.getTotalElements()); //make sure we only returned the one value
         assertEquals(tenantId, resources.getContent().get(0).getTenantId());
+        //assertThat(resources.get()., containsInAnyOrder(create.getResourceId(), create2.getResourceId()));
         assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
         assertEquals(Collections.emptyMap(), resources.getContent().get(0).getLabels());
     }

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -690,7 +690,6 @@ public class ResourceManagementTest {
         Page<Resource> resources = resourceManagement.getResourcesFromLabels(Collections.emptyMap(), tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
         assertEquals(2L, resources.getTotalElements()); //make sure we only returned the one value
         assertEquals(tenantId, resources.getContent().get(0).getTenantId());
-        //assertThat(resources.get()., containsInAnyOrder(create.getResourceId(), create2.getResourceId()));
         assertEquals(create.getResourceId(), resources.getContent().get(0).getResourceId());
         assertEquals(Collections.emptyMap(), resources.getContent().get(0).getLabels());
     }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-737

# What

Make sure that a resource with no labels will still match everything

# How

Alters the query to make sure that we are using an OUTER JOIN to find the resources that dont have any labels attached to them and still makes sure that we are only grabbing the resources for that tenant.

## How to test

Run the ResourceMangementTest's

# Why

It needs to be done at query time. We can't do it on the server because by the time we get there we would have already filtered out the resources that don't have labels.

# TODO

Everything should be done
