### PR TITLE
Removed codehaus jackson-mapper-asl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@
       <version>1.5.6</version>
     </dependency>
     <dependency>
-    <groupId>org.codehaus.jackson</groupId>
-    <artifactId>jackson-mapper-asl</artifactId>
-    <version>1.9.13</version>
-  </dependency>
-    <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-tools</artifactId>
       <version>0.0.1-SNAPSHOT</version>


### PR DESCRIPTION
# What

Github notified us of a security alert
https://github.com/racker/salus-telemetry-resource-management/network/alert/pom.xml/org.codehaus.jackson:jackson-mapper-asl/closed

We had a direct dependency on that library added by https://github.com/racker/salus-telemetry-resource-management/pull/20 that apparently wasn't even needed. All modern jackson libraries are situated in the fasterxml org and are supplied transitively by Spring dependencies.

# How

Removed the dependency and everything still builds fine.

## How to test

All the tests still work.