### PR TITLE
Fixed get-metadata-keys to handle resources with null metadata

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,16 @@ import static com.rackspace.salus.telemetry.model.LabelNamespaces.labelHasNamesp
 
 import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.resource_management.config.ResourceManagementProperties;
-import com.rackspace.salus.telemetry.entities.Resource;
-import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
-import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import com.rackspace.salus.resource_management.web.model.ResourceCreate;
 import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
+import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.messaging.AttachEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -477,9 +478,10 @@ public class ResourceManagement {
         .getResultStream();
 
     return resultStream
-        .flatMap(map -> map.keySet().stream()
-            .map(k -> (String) k)
-        )
+        // resources with no metadata rows get populated with a null field by JPA
+        // ...so filter to keep just the metadata maps that are non-null
+        .filter(Objects::nonNull)
+        .flatMap(map -> map.keySet().stream())
         .distinct()
         .collect(Collectors.toList());
   }

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -955,6 +956,18 @@ public class ResourceManagementTest {
             .getTenantResourceMetadataKeys("t-1");
 
         assertThat(results, equalTo(Arrays.asList("key1", "key2", "key3")));
+    }
+
+    @Test
+    public void testGetTenantResourceMetadataKeys_whenNull() {
+        persistResource("t-1", "r-1", Collections.emptyMap(), null);
+
+        entityManager.flush();
+
+        final List<String> results = resourceManagement
+            .getTenantResourceMetadataKeys("t-1");
+
+        assertThat(results, hasSize(0));
     }
 
     private void persistResource(String tenantId, String resourceId, Map<String, String> labels,


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-805

# What

When resources were present with no metadata, the `resource-metadata-keys` API endpoint would respond with a 500 and logs showed

```
java.lang.NullPointerException: null
--
at com.rackspace.salus.resource_management.services.ResourceManagement.lambda$getTenantResourceMetadataKeys$6(ResourceManagement.java:480)
at com.rackspace.salus.resource_management.services.ResourceManagement.getTenantResourceMetadataKeys(ResourceManagement.java:484)
at com.rackspace.salus.resource_management.web.controller.ResourceApiController.getResourceMetadataKeys(ResourceApiController.java:205)
```

# How

Filter away the null metadata maps.

## How to test

Added a unit test to recreate the bug and verify the fix.

cc @FarajiA 