### PR TITLE
added custom json deserializer and updated tests

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.resource_management.web.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.rackspace.salus.telemetry.translators.JsonToLowerCaseDeserializer;
 import java.io.Serializable;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
@@ -28,6 +30,7 @@ import javax.validation.constraints.NotBlank;
 public class ResourceCreate implements Serializable {
     @Pattern(regexp="[A-Za-z0-9:-]+")
     @NotBlank
+    @JsonDeserialize(using = JsonToLowerCaseDeserializer.class)
     String resourceId;
 
     Map<String,String> labels;

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -298,6 +298,7 @@ public class ResourceApiControllerTest {
         .andExpect(content()
             .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
 
+    create.setResourceId(create.getResourceId().toLowerCase());
     verify(resourceManagement).createResource(tenantId, create);
     verifyNoMoreInteractions(resourceManagement);
   }
@@ -318,6 +319,7 @@ public class ResourceApiControllerTest {
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andExpect(status().isUnprocessableEntity());
 
+    create.setResourceId(create.getResourceId().toLowerCase());
     verify(resourceManagement).createResource(tenantId, create);
     verifyNoMoreInteractions(resourceManagement);
   }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-694

# What

It is wanting to lowercase the resourceId's that come in so that it is obvious to users that resourceId's are case insensitive.

# How

It adds a customer JsonDeserializer on the resourceId field that lowercases everything

## How to test

Run the unit tests

# Why

Having this happen at JsonDeserialization time is good because it means that it happens before we get our hand on the POJO itself
