### PR TITLE
Default to empty maps

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.common.web.View;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,8 +17,8 @@ public class ResourceDTO {
   @JsonView(View.Internal.class)
   String tenantId;
   String resourceId;
-  Map<String,String> labels;
-  Map<String,String> metadata;
+  Map<String,String> labels = Collections.emptyMap();
+  Map<String,String> metadata = Collections.emptyMap();
   Boolean presenceMonitoringEnabled;
   boolean associatedWithEnvoy;
   String createdTimestamp;


### PR DESCRIPTION
This change goes along with my other zone policy changes:

https://github.com/racker/salus-telemetry-monitor-management/pull/164
https://github.com/racker/salus-policy-management/pull/31

By ensuring an empty map is set instead of `null` it allows for cleaner tests in the other repos that mock out `ResourceDTO`s

