### PR TITLE
Enable tenant id verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,18 @@
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
@@ -16,10 +16,12 @@
 
 package com.rackspace.salus.resource_management;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -30,6 +32,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableSalusKafkaMessaging
 @EnableExtendedErrorAttributes
 @EnableRoleBasedJsonViews
+@EnableTenantVerification
+@AutoConfigureSalusAppMetrics
 public class TelemetryResourceManagementApplication {
 
   public static void main(String[] args) {

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
@@ -63,6 +65,9 @@ public class ResourceApiClientTest {
 
   @Autowired
   ResourceApiClient resourceApiClient;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   private PodamFactory podamFactory = new PodamFactoryImpl();
 


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.