### PR TITLE
Adam9500/salus 836 update resource details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
       <version>0.1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-etcd-adapter</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/resource_management/TelemetryResourceManagementApplication.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
+import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -34,6 +35,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableRoleBasedJsonViews
 @EnableTenantVerification
 @AutoConfigureSalusAppMetrics
+@EnableEtcd
 public class TelemetryResourceManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -482,7 +482,7 @@ public class ResourceManagement {
         (resultSet, rowIndex) -> resultSet.getLong(1)
     );
 
-    return resourceRepository.findAllByResourceIdIn(resourceIds, page);
+    return resourceRepository.findByIdIn(resourceIds, page);
 
   }
 

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -145,7 +145,7 @@ public class ResourceManagement {
   public ResourceDTO getResourceDTO(String tenantId, String resourceId) {
     Optional<Resource> resource = resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
 
-    if(resource.get() == null) {
+    if(!resource.isPresent()) {
       throw new NotFoundException(String.format("No resource found for %s on tenant %s",
           resourceId, tenantId));
     }
@@ -161,7 +161,7 @@ public class ResourceManagement {
   public Page<ResourceDTO> getAllResourceDTOs(Pageable page) {
     final List<ResourceDTO> values = new LinkedList();
     resourceRepository.findAll().forEach(r -> {
-      values.add(new ResourceDTO(r,null)); //envoyResourceManagement.getOne(r.getTenantId(), r.getResourceId()).join().getEnvoyId()));
+      values.add(getResourceDTOFromResource(r));
     });
     return new PageImpl(values, page, values.size());
   }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -159,12 +159,8 @@ public class ResourceManagement {
    * @return The resourceDTOs found that match the page criteria.
    */
   public Page<ResourceDTO> getAllResourceDTOs(Pageable page) {
-    final List<ResourceDTO> resourceDTOs = new LinkedList();
-    Page<Resource> resources = resourceRepository.findAll(page);
-    resources.forEach(r -> {
-      resourceDTOs.add(getResourceDTOFromResource(r));
-    });
-    return new PageImpl(resourceDTOs, page, resources.getTotalElements());
+    return resourceRepository.findAll(page)
+        .map(this::getResourceDTOFromResource);
   }
 
   /**
@@ -174,14 +170,8 @@ public class ResourceManagement {
    * @return The resources found for the tenant that match the page criteria.
    */
   public Page<ResourceDTO> getResourceDTOs(String tenantId, Pageable page) {
-    final List<ResourceDTO> resourceDTOs = new LinkedList();
-    Page<Resource> resources = resourceRepository.findAllByTenantId(tenantId, page);
-
-    resources.forEach(r -> {
-      resourceDTOs.add(getResourceDTOFromResource(r));
-    });
-
-    return new PageImpl(resourceDTOs, page, resources.getTotalElements());
+    return resourceRepository.findAllByTenantId(tenantId, page)
+        .map(this::getResourceDTOFromResource);
   }
 
   /**
@@ -433,12 +423,8 @@ public class ResourceManagement {
   }
 
   public Page<ResourceDTO> getResourceDTOsFromLabels(Map<String, String> labels, String tenantId, LabelSelectorMethod logicalOperation, Pageable page) {
-    Page<Resource> pagedResources = getResourcesFromLabels(labels, tenantId, logicalOperation, page);
-    final List<ResourceDTO> values = new LinkedList();
-    pagedResources.get().forEach(r -> {
-      values.add(getResourceDTOFromResource(r));
-    });
-    return new PageImpl(values, page, pagedResources.getTotalElements());
+    return getResourcesFromLabels(labels, tenantId, logicalOperation, page)
+      .map(this::getResourceDTOFromResource);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -554,10 +554,10 @@ public class ResourceManagement {
   }
 
   private ResourceDTO getResourceDTOFromResource(Resource resource) {
+    ResourceInfo resourceInfo = envoyResourceManagement.getOne(resource.getTenantId(), resource.getResourceId()).join();
+
     return new ResourceDTO(resource,
-        envoyResourceManagement.getOne(resource.getTenantId(), resource.getResourceId())
-            .join()
-            .getEnvoyId());
+        resourceInfo == null ? null : resourceInfo.getEnvoyId());
   }
 
   public Collection<String> getLabelNamespaces() {

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -143,14 +143,11 @@ public class ResourceManagement {
   }
 
   public ResourceDTO getResourceDTO(String tenantId, String resourceId) {
-    Optional<Resource> resource = resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
+    Resource resource = resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId)
+        .orElseThrow(() -> new NotFoundException(
+            String.format("No resource found for %s on tenant %s", resourceId, tenantId)));
 
-    if(!resource.isPresent()) {
-      throw new NotFoundException(String.format("No resource found for %s on tenant %s",
-          resourceId, tenantId));
-    }
-
-    return getResourceDTOFromResource(resource.get());
+    return getResourceDTOFromResource(resource);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -144,13 +144,13 @@ public class ResourceManagement {
 
   public ResourceDTO getResourceDTO(String tenantId, String resourceId) {
     Optional<Resource> resource = resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
-    // we need to get the
+
     if(resource.get() == null) {
       throw new NotFoundException(String.format("No resource found for %s on tenant %s",
           resourceId, tenantId));
     }
-    String envoyId = envoyResourceManagement.getOne(resource.get().getTenantId(), resource.get().getResourceId()).join().getEnvoyId();
-    return new ResourceDTO(resource.get(), null);
+
+    return getResourceDTOFromResource(resource.get());
   }
 
   /**
@@ -167,7 +167,7 @@ public class ResourceManagement {
   }
 
   /**
-   * Same as {@link #getAllResourceDTOs(Pageable page) getAllResources} except restricted to a single tenant.
+   * Same as {@link #getAllResourceDTOs(Pageable page) getAllResourceDTOs} except restricted to a single tenant.
    * @param tenantId The tenant to select resources from.
    * @param page The slice of results to be returned.
    * @return The resources found for the tenant that match the page criteria.
@@ -175,7 +175,7 @@ public class ResourceManagement {
   public Page<ResourceDTO> getResourceDTOs(String tenantId, Pageable page) {
     final List<ResourceDTO> values = new LinkedList();
     resourceRepository.findAllByTenantId(tenantId).forEach(r -> {
-      values.add(new ResourceDTO(r, null));//envoyResourceManagement.getOne(r.getTenantId(), r.getResourceId()).join().getEnvoyId()));
+      values.add(getResourceDTOFromResource(r));
     });
 
     return new PageImpl(values, page, values.size());
@@ -219,7 +219,7 @@ public class ResourceManagement {
    * @throws IllegalArgumentException
    * @throws AlreadyExistsException
    */
-  public Resource createResource(String tenantId, @Valid ResourceCreate newResource) throws IllegalArgumentException, AlreadyExistsException {
+  public ResourceDTO createResource(String tenantId, @Valid ResourceCreate newResource) throws IllegalArgumentException, AlreadyExistsException {
     if (exists(tenantId, newResource.getResourceId())) {
       throw new AlreadyExistsException(String.format("Resource already exists with identifier %s on tenant %s",
           newResource.getResourceId(), tenantId));
@@ -238,7 +238,7 @@ public class ResourceManagement {
 
     resource = saveAndPublishResource(resource, true, null);
 
-    return resource;
+    return getResourceDTOFromResource(resource);
   }
 
   /**
@@ -437,7 +437,7 @@ public class ResourceManagement {
     Page<Resource> pagedResources = getResourcesFromLabels(labels, tenantId, logicalOperation, page);
     final List<ResourceDTO> values = new LinkedList();
     pagedResources.get().forEach(r -> {
-      values.add(new ResourceDTO(r, null));//envoyResourceManagement.getOne(r.getTenantId(), r.getResourceId()).join().getEnvoyId()));
+      values.add(getResourceDTOFromResource(r));
     });
     return (Page<ResourceDTO>) getPagedResults(values, page);
   }

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -34,20 +34,15 @@ import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
@@ -176,10 +171,9 @@ public class ResourceManagement {
    * @param presenceMonitoringEnabled Whether presence monitoring is enabled or not.
    * @return Stream of resources.
    */
-  public Stream<ResourceDTO> getResources(boolean presenceMonitoringEnabled) {
+  public Stream<Resource> getResources(boolean presenceMonitoringEnabled) {
     return resourceRepository.findAllByPresenceMonitoringEnabled(presenceMonitoringEnabled)
-        .stream()
-        .map(this::getResourceDTOFromResource);
+        .stream();
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -337,7 +337,8 @@ public class ResourceManagement {
           .setTenantId(tenantId)
           .setResourceId(resourceId)
           .setLabels(labels)
-          .setPresenceMonitoringEnabled(true);
+          .setPresenceMonitoringEnabled(true)
+          .setAssociatedWithEnvoy(true);
       saveAndPublishResource(newResource, true, null);
     }
   }
@@ -394,6 +395,7 @@ public class ResourceManagement {
     if (labelsChanged || !reattached) {
       // ...then save it
 
+      existingResource.setAssociatedWithEnvoy(true);
       existingResource.setLabels(resourceLabels);
 
       log.debug("Saving resource due to Envoy attachment: {}", existingResource);
@@ -552,8 +554,10 @@ public class ResourceManagement {
   }
 
   private ResourceDTO getResourceDTOFromResource(Resource resource) {
-    return new ResourceDTO(resource,null);
-        //envoyResourceManagement.getOne(resource.getTenantId(), resource.getResourceId()).join().getEnvoyId());
+    return new ResourceDTO(resource,
+        envoyResourceManagement.getOne(resource.getTenantId(), resource.getResourceId())
+            .join()
+            .getEnvoyId());
   }
 
   public Collection<String> getLabelNamespaces() {

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -91,7 +91,7 @@ public class ResourceApiController {
   @GetMapping("/envoys")
   public SseEmitter getAllWithPresenceMonitoringAsStream() {
     SseEmitter emitter = new SseEmitter();
-    Stream<ResourceDTO> resourcesWithEnvoys = resourceManagement.getResources(true);
+    Stream<Resource> resourcesWithEnvoys = resourceManagement.getResources(true);
     taskExecutor.execute(() -> {
       resourcesWithEnvoys.forEach(r -> {
         try {

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -110,9 +110,7 @@ public class ResourceApiController {
   @ApiOperation(value = "Gets specific Resource for specific Tenant")
   public ResourceDTO getByResourceId(@PathVariable String tenantId,
       @PathVariable String resourceId) throws NotFoundException {
-
-    ResourceDTO resourceDTO = resourceManagement.getResourceDTO(tenantId, resourceId);
-    return resourceDTO;
+    return resourceManagement.getResourceDTO(tenantId, resourceId);
   }
 
   @GetMapping("/tenant/{tenantId}/resources")
@@ -153,8 +151,6 @@ public class ResourceApiController {
   public List<ResourceDTO> getAllTenantResourcesWithLabels(@PathVariable String tenantId,
                                                            @RequestParam Map<String, String> labels,
                                                            @PathVariable LabelSelectorMethod logicalOperator) {
-
-
     return resourceManagement
         .getResourceDTOsFromLabels(labels, tenantId, logicalOperator, Pageable.unpaged()).getContent();
   }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -95,7 +95,7 @@ public class ResourceApiController {
     taskExecutor.execute(() -> {
       resourcesWithEnvoys.forEach(r -> {
         try {
-          emitter.send(r);
+          emitter.send(new ResourceDTO(r, null));
         } catch (IOException e) {
           emitter.completeWithError(e);
         }

--- a/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/controller/ResourceApiController.java
@@ -129,7 +129,7 @@ public class ResourceApiController {
   public ResourceDTO create(@PathVariable String tenantId,
       @Valid @RequestBody final ResourceCreate input)
       throws IllegalArgumentException, AlreadyExistsException {
-    return new ResourceDTO(resourceManagement.createResource(tenantId, input), null);
+    return resourceManagement.createResource(tenantId, input);
   }
 
   @PutMapping("/tenant/{tenantId}/resources/{resourceId}")

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -16,9 +16,9 @@ public class ResourceDTO {
   Long id;
   @JsonView(View.Internal.class)
   String tenantId;
-  @JsonView(View.Internal.class)
-  String envoyId;
   @JsonView(View.Admin.class)
+  String envoyId;
+  @JsonView(View.Internal.class)
   boolean associatedWithEnvoy;
   String resourceId;
   Map<String,String> labels = Collections.emptyMap();

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -16,6 +16,8 @@ public class ResourceDTO {
   Long id;
   @JsonView(View.Internal.class)
   String tenantId;
+  @JsonView(View.Internal.class)
+  String envoyId;
   String resourceId;
   Map<String,String> labels = Collections.emptyMap();
   Map<String,String> metadata = Collections.emptyMap();
@@ -24,14 +26,14 @@ public class ResourceDTO {
   String createdTimestamp;
   String updatedTimestamp;
 
-  public ResourceDTO(Resource resource) {
+  public ResourceDTO(Resource resource, String envoyId) {
     this.id = resource.getId();
     this.tenantId = resource.getTenantId();
     this.resourceId = resource.getResourceId();
     this.labels = resource.getLabels();
     this.metadata = resource.getMetadata();
     this.presenceMonitoringEnabled = resource.getPresenceMonitoringEnabled();
-    this.associatedWithEnvoy = resource.isAssociatedWithEnvoy();
+    this.associatedWithEnvoy = envoyId != null;
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getUpdatedTimestamp());
   }

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -18,11 +18,12 @@ public class ResourceDTO {
   String tenantId;
   @JsonView(View.Internal.class)
   String envoyId;
+  @JsonView(View.Admin.class)
+  boolean associatedWithEnvoy;
   String resourceId;
   Map<String,String> labels = Collections.emptyMap();
   Map<String,String> metadata = Collections.emptyMap();
   Boolean presenceMonitoringEnabled;
-  boolean associatedWithEnvoy;
   String createdTimestamp;
   String updatedTimestamp;
 
@@ -33,6 +34,8 @@ public class ResourceDTO {
     this.labels = resource.getLabels();
     this.metadata = resource.getMetadata();
     this.presenceMonitoringEnabled = resource.getPresenceMonitoringEnabled();
+    this.associatedWithEnvoy = envoyId != null;
+    this.envoyId = envoyId;
     this.associatedWithEnvoy = envoyId != null;
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getUpdatedTimestamp());

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -34,7 +34,7 @@ public class ResourceDTO {
     this.labels = resource.getLabels();
     this.metadata = resource.getMetadata();
     this.presenceMonitoringEnabled = resource.getPresenceMonitoringEnabled();
-    this.associatedWithEnvoy = envoyId != null;
+    this.associatedWithEnvoy = resource.isAssociatedWithEnvoy();
     this.envoyId = envoyId;
     this.createdTimestamp = resource.getCreatedTimestamp() == null ? null : DateTimeFormatter.ISO_INSTANT.format(resource.getCreatedTimestamp());
     this.updatedTimestamp = resource.getUpdatedTimestamp() == null ? null : DateTimeFormatter.ISO_INSTANT.format(resource.getUpdatedTimestamp());

--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceDTO.java
@@ -36,8 +36,7 @@ public class ResourceDTO {
     this.presenceMonitoringEnabled = resource.getPresenceMonitoringEnabled();
     this.associatedWithEnvoy = envoyId != null;
     this.envoyId = envoyId;
-    this.associatedWithEnvoy = envoyId != null;
-    this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getCreatedTimestamp());
-    this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(resource.getUpdatedTimestamp());
+    this.createdTimestamp = resource.getCreatedTimestamp() == null ? null : DateTimeFormatter.ISO_INSTANT.format(resource.getCreatedTimestamp());
+    this.updatedTimestamp = resource.getUpdatedTimestamp() == null ? null : DateTimeFormatter.ISO_INSTANT.format(resource.getUpdatedTimestamp());
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 salus:
   environment: local
+  etcd.url: http://localhost:2479
 spring:
   kafka:
     producer:

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -227,6 +227,15 @@ public class ResourceManagementTest {
 
     @Test
     public void testGetResourcesWithPresenceMonitoringAsStream() {
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId("t-1")
+            .setResourceId("r-1");
+
+        CompletableFuture<ResourceInfo> envoyInformation = CompletableFuture.completedFuture(info);
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(envoyInformation);
         int totalResources = 100;
         createResources(totalResources);
         Stream s = resourceManagement.getResources(true);
@@ -437,6 +446,7 @@ public class ResourceManagementTest {
                 .setLabels(resourceLabels)
                 .setTenantId("t-1")
                 .setPresenceMonitoringEnabled(false)
+                .setAssociatedWithEnvoy(true)
         );
         entityManager.flush();
 
@@ -487,6 +497,15 @@ public class ResourceManagementTest {
           .setLabels(newLabels)
           .setPresenceMonitoringEnabled(presenceMonitoring);
 
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId("t-1")
+            .setResourceId("r-1");
+
+        CompletableFuture<ResourceInfo> envoyInformation = CompletableFuture.completedFuture(info);
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(envoyInformation);
+
         ResourceDTO newResource;
         try {
             newResource = resourceManagement.updateResource(
@@ -530,6 +549,14 @@ public class ResourceManagementTest {
             .setMetadata(newMetadata)
             .setPresenceMonitoringEnabled(presenceMonitoring);
 
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId("t-1")
+            .setResourceId("r-1");
+
+        CompletableFuture<ResourceInfo> envoyInformation = CompletableFuture.completedFuture(info);
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(envoyInformation);
         ResourceDTO newResource = resourceManagement.updateResource(
             resource.getTenantId(),
             resource.getResourceId(),

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -517,6 +517,8 @@ public class ResourceManagementTest {
             return;
         }
 
+        resource = resourceManagement.getAllResourceDTOs(PageRequest.of(0, 1)).getContent().get(0);
+
         assertThat(newResource.getLabels(), equalTo(resource.getLabels()));
         assertThat(newResource.getId(), equalTo(resource.getId()));
         assertThat(newResource.getPresenceMonitoringEnabled(), equalTo(presenceMonitoring));

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -139,6 +139,15 @@ public class ResourceManagementTest {
             ResourceCreate create = podamFactory.manufacturePojo(ResourceCreate.class);
             String resourceId = RandomStringUtils.randomAlphanumeric(10);
             create.setResourceId(resourceId);
+
+            ResourceInfo info = new ResourceInfo()
+                .setEnvoyId("e-1")
+                .setTenantId(tenantId)
+                .setResourceId(resourceId);
+
+            when(envoyResourceManagement.getOne(tenantId, resourceId))
+                .thenReturn(CompletableFuture.completedFuture(info));
+
             resourceManagement.createResource(tenantId, create);
         }
     }
@@ -167,7 +176,15 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
 
-        Resource returned = resourceManagement.createResource(tenantId, create);
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
+        ResourceDTO returned = resourceManagement.createResource(tenantId, create);
 
         assertThat(returned.getId(), notNullValue());
         assertThat(returned.getResourceId(), equalTo(create.getResourceId()));
@@ -215,6 +232,13 @@ public class ResourceManagementTest {
         Page<ResourceDTO> result = resourceManagement.getAllResourceDTOs(page);
 
         assertThat(result.getTotalElements(), equalTo(1L));
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
 
         createResourcesForTenant(totalResources , tenantId);
 
@@ -581,6 +605,15 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
 
         Optional<Resource> created = resourceManagement.getResource(tenantId, create.getResourceId());
@@ -635,6 +668,15 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
         Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.AND, Pageable.unpaged());
@@ -654,6 +696,15 @@ public class ResourceManagementTest {
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String tenantId2 = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         resourceManagement.createResource(tenantId2, create);
 
@@ -674,6 +725,13 @@ public class ResourceManagementTest {
         String tenantId2 = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
         resourceManagement.createResource(tenantId, create);
         resourceManagement.createResource(tenantId2, create);
 
@@ -694,6 +752,15 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -718,6 +785,15 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -740,6 +816,15 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
 
 
@@ -802,6 +887,15 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -824,8 +918,19 @@ public class ResourceManagementTest {
         create.setResourceId(resourceId);
         create.setLabels(resourceLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
+
+
 
         Page<Resource> resources = resourceManagement.getResourcesFromLabels(labels, tenantId, LabelSelectorMethod.OR, Pageable.unpaged());
         assertEquals(0L, resources.getTotalElements());
@@ -846,6 +951,15 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -871,6 +985,15 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -896,6 +1019,14 @@ public class ResourceManagementTest {
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -919,6 +1050,15 @@ public class ResourceManagementTest {
         create.setResourceId(resourceId);
         create.setLabels(resourceLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 
@@ -937,6 +1077,15 @@ public class ResourceManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String resourceId = RandomStringUtils.randomAlphanumeric(10);
         create.setResourceId(resourceId);
+
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(tenantId)
+            .setResourceId(resourceId);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
+
         resourceManagement.createResource(tenantId, create);
         entityManager.flush();
 

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -205,6 +205,12 @@ public class ResourceManagementTest {
         Random random = new Random();
         int totalResources = random.nextInt(150 - 50) + 50;
         int pageSize = 10;
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(TENANT);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(info));
 
         Pageable page = PageRequest.of(0, pageSize);
         Page<ResourceDTO> result = resourceManagement.getAllResourceDTOs(page);
@@ -228,17 +234,17 @@ public class ResourceManagementTest {
         int pageSize = 10;
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
 
-        Pageable page = PageRequest.of(0, pageSize);
-        Page<ResourceDTO> result = resourceManagement.getAllResourceDTOs(page);
-
-        assertThat(result.getTotalElements(), equalTo(1L));
-
         ResourceInfo info = new ResourceInfo()
             .setEnvoyId("e-1")
             .setTenantId(tenantId);
 
         when(envoyResourceManagement.getOne(any(), any()))
             .thenReturn(CompletableFuture.completedFuture(info));
+
+        Pageable page = PageRequest.of(0, pageSize);
+        Page<ResourceDTO> result = resourceManagement.getAllResourceDTOs(page);
+
+        assertThat(result.getTotalElements(), equalTo(1L));
 
         createResourcesForTenant(totalResources , tenantId);
 
@@ -513,6 +519,13 @@ public class ResourceManagementTest {
 
     @Test
     public void testUpdateExistingResource() {
+        ResourceInfo info = new ResourceInfo()
+            .setEnvoyId("e-1")
+            .setTenantId(TENANT)
+            .setResourceId(RESOURCE_ID);
+
+        when(envoyResourceManagement.getOne(any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(info));
         ResourceDTO resource = resourceManagement.getAllResourceDTOs(PageRequest.of(0, 1)).getContent().get(0);
         Map<String, String> newLabels = new HashMap<>(resource.getLabels());
         newLabels.put("newLabel", "newValue");
@@ -520,15 +533,6 @@ public class ResourceManagementTest {
         ResourceUpdate update = new ResourceUpdate()
           .setLabels(newLabels)
           .setPresenceMonitoringEnabled(presenceMonitoring);
-
-        ResourceInfo info = new ResourceInfo()
-            .setEnvoyId("e-1")
-            .setTenantId("t-1")
-            .setResourceId("r-1");
-
-        CompletableFuture<ResourceInfo> envoyInformation = CompletableFuture.completedFuture(info);
-        when(envoyResourceManagement.getOne(any(), any()))
-            .thenReturn(envoyInformation);
 
         ResourceDTO newResource;
         try {

--- a/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/ResourceManagementTest.java
@@ -191,6 +191,7 @@ public class ResourceManagementTest {
         assertThat(returned.getPresenceMonitoringEnabled(), notNullValue());
         assertThat(returned.getPresenceMonitoringEnabled(), equalTo(create.getPresenceMonitoringEnabled()));
         assertThat(returned.getLabels().size(), greaterThan(0));
+        assertThat(returned.getEnvoyId(), equalTo("e-1"));
         assertTrue(Maps.difference(create.getLabels(), returned.getLabels()).areEqual());
 
         Optional<Resource> retrieved = resourceManagement.getResource(tenantId, create.getResourceId());
@@ -547,6 +548,7 @@ public class ResourceManagementTest {
 
         resource = resourceManagement.getAllResourceDTOs(PageRequest.of(0, 1)).getContent().get(0);
 
+        assertThat(newResource.getEnvoyId(), equalTo("e-1"));
         assertThat(newResource.getLabels(), equalTo(resource.getLabels()));
         assertThat(newResource.getId(), equalTo(resource.getId()));
         assertThat(newResource.getPresenceMonitoringEnabled(), equalTo(presenceMonitoring));
@@ -600,7 +602,7 @@ public class ResourceManagementTest {
         assertThat(newResource.getLabels(), equalTo(expectedLabels));
         assertThat(newResource.getMetadata(), equalTo(resource.getMetadata()));
         assertThat(newResource.getId(), equalTo(resource.getId()));
-        //assertThat(newResource.getPresenceMonitoringEnabled(), equalTo(presenceMonitoring));
+        assertThat(newResource.getPresenceMonitoringEnabled(), equalTo(presenceMonitoring));
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -338,7 +338,7 @@ public class ResourceApiControllerTest {
 
   @Test
   public void testCreateResource() throws Exception {
-    Resource resource = podamFactory.manufacturePojo(Resource.class);
+    ResourceDTO resource = podamFactory.manufacturePojo(ResourceDTO.class);
     String resourceId = "resource28-13:databaseNode";
     resource.setResourceId(resourceId);
     when(resourceManagement.createResource(anyString(), any()))

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -228,13 +228,10 @@ public class ResourceApiControllerTest {
     when(resourceManagement.getResourceDTO(any(), any()))
         .thenReturn(expectedResource);
 
-    ResultActions value = mockMvc.perform(get(
+    mockMvc.perform(get(
         "/api/tenant/{tenantId}/resources/{resourceId}",
         "t-1", "r-1"
-    ).accept(MediaType.APPLICATION_JSON));
-
-
-        value
+    ).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().json(
             // id field should not be returned

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -494,9 +494,9 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetStreamOfResources() throws Exception {
     int numberOfResources = 20;
-    List<ResourceDTO> resources = new ArrayList<>();
+    List<Resource> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
-      resources.add(podamFactory.manufacturePojo(ResourceDTO.class));
+      resources.add(podamFactory.manufacturePojo(Resource.class));
     }
 
     List<String> expectedData = resources.stream()
@@ -510,7 +510,7 @@ public class ResourceApiControllerTest {
         }).collect(Collectors.toList());
     assertThat(expectedData.size(), equalTo(resources.size()));
 
-    Stream<ResourceDTO> resourceStream = resources.stream();
+    Stream<Resource> resourceStream = resources.stream();
 
     when(resourceManagement.getResources(true))
         .thenReturn(resourceStream);

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -502,7 +502,7 @@ public class ResourceApiControllerTest {
     List<String> expectedData = resources.stream()
         .map(r -> {
           try {
-            return "data:" + objectMapper.writeValueAsString(r);
+            return "data:" + objectMapper.writeValueAsString(new ResourceDTO(r, null));
           } catch (JsonProcessingException e) {
             assertThat(e, nullValue());
             return null;

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -75,6 +75,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -184,17 +185,17 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetByResourceIdAsEmployee() throws Exception {
 
-    final Resource expectedResource = new Resource()
+    final ResourceDTO expectedResource = new ResourceDTO()
         .setLabels(Collections.singletonMap("env", "prod"))
         .setMetadata(Collections.singletonMap("custom", "new"))
         .setResourceId("r-1")
         .setTenantId("t-1")
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP)
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP.toString())
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP.toString())
         .setAssociatedWithEnvoy(false)
         .setId(1001L);
-    when(resourceManagement.getResource(any(), any()))
-        .thenReturn(Optional.of(expectedResource));
+    when(resourceManagement.getResourceDTO(any(), any()))
+        .thenReturn(expectedResource);
 
     mockMvc.perform(get(
         "/api/tenant/{tenantId}/resources/{resourceId}",
@@ -206,7 +207,7 @@ public class ResourceApiControllerTest {
             SpringResourceUtils.readContent(
                 "ResourceApiControllerTest/single_public_resource_employee.json"), true));
 
-    verify(resourceManagement).getResource("t-1", "r-1");
+    verify(resourceManagement).getResourceDTO("t-1", "r-1");
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -214,29 +215,32 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetByResourceIdAsAdmin() throws Exception {
 
-    final Resource expectedResource = new Resource()
+    final ResourceDTO expectedResource = new ResourceDTO()
         .setLabels(Collections.singletonMap("env", "prod"))
         .setMetadata(Collections.singletonMap("custom", "new"))
         .setResourceId("r-1")
         .setTenantId("t-1")
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP)
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP.toString())
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP.toString())
         .setAssociatedWithEnvoy(false)
         .setId(1001L);
-    when(resourceManagement.getResource(any(), any()))
-        .thenReturn(Optional.of(expectedResource));
+    when(resourceManagement.getResourceDTO(any(), any()))
+        .thenReturn(expectedResource);
 
-    mockMvc.perform(get(
+    ResultActions value = mockMvc.perform(get(
         "/api/tenant/{tenantId}/resources/{resourceId}",
         "t-1", "r-1"
-    ).accept(MediaType.APPLICATION_JSON))
+    ).accept(MediaType.APPLICATION_JSON));
+
+
+        value
         .andExpect(status().isOk())
         .andExpect(content().json(
             // id field should not be returned
             SpringResourceUtils.readContent(
                 "ResourceApiControllerTest/single_public_resource_admin.json"), true));
 
-    verify(resourceManagement).getResource("t-1", "r-1");
+    verify(resourceManagement).getResourceDTO("t-1", "r-1");
     verifyNoMoreInteractions(resourceManagement);
   }
 

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -46,6 +46,7 @@ import com.rackspace.salus.resource_management.web.model.ResourceUpdate;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import com.rackspace.salus.telemetry.web.TenantVerification;
 import java.nio.charset.StandardCharsets;
@@ -109,9 +110,9 @@ public class ResourceApiControllerTest {
     String tenantId = RandomStringUtils.randomAlphabetic( 8 );
     String resourceId = RandomStringUtils.randomAlphabetic( 8 );
     String errorMsg = String.format("No resource found for %s on tenant %s", resourceId, tenantId);
-
-    when(resourceManagement.getResource(anyString(), anyString()))
-        .thenReturn(Optional.empty());
+    NotFoundException exception = new NotFoundException(errorMsg);
+    when(resourceManagement.getResourceDTO(anyString(), anyString()))
+        .thenThrow(exception);
     when(tenantMetadataRepository.existsByTenantId(tenantId))
         .thenReturn(true);
 
@@ -153,16 +154,17 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetByResourceIdAsCustomer() throws Exception {
 
-    final Resource expectedResource = new Resource()
+    final ResourceDTO expectedResource = new ResourceDTO()
         .setLabels(Collections.singletonMap("env", "prod"))
         .setMetadata(Collections.singletonMap("custom", "new"))
         .setResourceId("r-1")
         .setTenantId("t-1")
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP)
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP.toString())
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP.toString())
+        .setAssociatedWithEnvoy(true)
         .setId(1001L);
-    when(resourceManagement.getResource(any(), any()))
-        .thenReturn(Optional.of(expectedResource));
+    when(resourceManagement.getResourceDTO(any(), any()))
+        .thenReturn(expectedResource);
 
     mockMvc.perform(get(
         "/api/tenant/{tenantId}/resources/{resourceId}",
@@ -174,7 +176,7 @@ public class ResourceApiControllerTest {
             SpringResourceUtils.readContent(
                 "ResourceApiControllerTest/single_public_resource_customer.json"), true));
 
-    verify(resourceManagement).getResource("t-1", "r-1");
+    verify(resourceManagement).getResourceDTO("t-1", "r-1");
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -189,6 +191,7 @@ public class ResourceApiControllerTest {
         .setTenantId("t-1")
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP)
+        .setAssociatedWithEnvoy(false)
         .setId(1001L);
     when(resourceManagement.getResource(any(), any()))
         .thenReturn(Optional.of(expectedResource));
@@ -218,6 +221,7 @@ public class ResourceApiControllerTest {
         .setTenantId("t-1")
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP)
+        .setAssociatedWithEnvoy(false)
         .setId(1001L);
     when(resourceManagement.getResource(any(), any()))
         .thenReturn(Optional.of(expectedResource));
@@ -238,12 +242,12 @@ public class ResourceApiControllerTest {
 
   @Test
   public void testNoResourceFound() throws Exception {
-    when(resourceManagement.getResource(anyString(), anyString()))
-        .thenReturn(Optional.empty());
-
     String tenantId = RandomStringUtils.randomAlphabetic( 8 );
     String resourceId = RandomStringUtils.randomAlphabetic( 8 );
     String errorMsg = String.format("No resource found for %s on tenant %s", resourceId, tenantId);
+    NotFoundException exception = new NotFoundException(errorMsg);
+    when(resourceManagement.getResourceDTO(anyString(), anyString()))
+        .thenThrow(exception);
 
     mockMvc.perform(get("/api/tenant/{tenantId}/resources/{resourceId}", tenantId, resourceId)
         .contentType(MediaType.APPLICATION_JSON))
@@ -252,7 +256,7 @@ public class ResourceApiControllerTest {
             .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.message", is(errorMsg)));
 
-    verify(resourceManagement).getResource(tenantId, resourceId);
+    verify(resourceManagement).getResourceDTO(tenantId, resourceId);
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -262,18 +266,18 @@ public class ResourceApiControllerTest {
     // Use the APIs default Pageable settings
     int page = 0;
     int pageSize = 20;
-    List<Resource> resources = new ArrayList<>();
+    List<ResourceDTO> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
-      resources.add(podamFactory.manufacturePojo(Resource.class));
+      resources.add(podamFactory.manufacturePojo(ResourceDTO.class));
     }
 
     int start = page * pageSize;
     int end = numberOfResources;
-    Page<Resource> pageOfResources = new PageImpl<>(resources.subList(start, end),
+    Page<ResourceDTO> pageOfResources = new PageImpl<>(resources.subList(start, end),
         PageRequest.of(page, pageSize),
         numberOfResources);
 
-    when(resourceManagement.getResources(anyString(), any()))
+    when(resourceManagement.getResourceDTOs(anyString(), any()))
         .thenReturn(pageOfResources);
 
     String tenantId = RandomStringUtils.randomAlphabetic( 8 );
@@ -287,7 +291,7 @@ public class ResourceApiControllerTest {
         .andExpect(jsonPath("$.totalPages", equalTo(1)))
         .andExpect(jsonPath("$.totalElements", equalTo(numberOfResources)));
 
-    verify(resourceManagement).getResources(tenantId, PageRequest.of(0, 20));
+    verify(resourceManagement).getResourceDTOs(tenantId, PageRequest.of(0, 20));
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -296,20 +300,20 @@ public class ResourceApiControllerTest {
     int numberOfResources = 99;
     int pageSize = 4;
     int page = 14;
-    List<Resource> resources = new ArrayList<>();
+    List<ResourceDTO> resourceDTOs = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
-      resources.add(podamFactory.manufacturePojo(Resource.class));
+      resourceDTOs.add(podamFactory.manufacturePojo(ResourceDTO.class));
     }
     int start = page * pageSize;
     int end = start + pageSize;
-    Page<Resource> pageOfResources = new PageImpl<>(resources.subList(start, end),
+    Page<ResourceDTO> pageOfResourceDTOs = new PageImpl<>(resourceDTOs.subList(start, end),
         PageRequest.of(page, pageSize),
         numberOfResources);
 
-    assertThat(pageOfResources.getContent().size(), equalTo(pageSize));
+    assertThat(pageOfResourceDTOs.getContent().size(), equalTo(pageSize));
 
-    when(resourceManagement.getResources(anyString(), any()))
-        .thenReturn(pageOfResources);
+    when(resourceManagement.getResourceDTOs(anyString(), any()))
+        .thenReturn(pageOfResourceDTOs);
 
     String tenantId = RandomStringUtils.randomAlphabetic( 8 );
 
@@ -324,7 +328,7 @@ public class ResourceApiControllerTest {
         .andExpect(jsonPath("$.totalPages", equalTo((numberOfResources + pageSize - 1) / pageSize)))
         .andExpect(jsonPath("$.totalElements", equalTo(numberOfResources)));
 
-    verify(resourceManagement).getResources(tenantId, PageRequest.of(page, pageSize));
+    verify(resourceManagement).getResourceDTOs(tenantId, PageRequest.of(page, pageSize));
     verifyNoMoreInteractions(resourceManagement);
   }
 
@@ -430,13 +434,13 @@ public class ResourceApiControllerTest {
 
   @Test
   public void testUpdateResource() throws Exception {
-    Resource resource = podamFactory.manufacturePojo(Resource.class);
+    ResourceDTO resourceDTO = podamFactory.manufacturePojo(ResourceDTO.class);
     when(resourceManagement.updateResource(anyString(), anyString(), any()))
-        .thenReturn(resource);
-    resource.setResourceId(RandomStringUtils.randomAlphabetic(8));
+        .thenReturn(resourceDTO);
+    resourceDTO.setResourceId(RandomStringUtils.randomAlphabetic(8));
 
-    String tenantId = resource.getTenantId();
-    String resourceId = resource.getResourceId();
+    String tenantId = resourceDTO.getTenantId();
+    String resourceId = resourceDTO.getResourceId();
 
     ResourceUpdate update = podamFactory.manufacturePojo(ResourceUpdate.class);
 
@@ -458,19 +462,19 @@ public class ResourceApiControllerTest {
     // Use the APIs default Pageable settings
     int page = 0;
     int pageSize = 20;
-    List<Resource> resources = new ArrayList<>();
+    List<ResourceDTO> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
-      resources.add(podamFactory.manufacturePojo(Resource.class));
+      resources.add(podamFactory.manufacturePojo(ResourceDTO.class));
     }
 
     int start = page * pageSize;
     int end = numberOfResources;
-    Page<Resource> pageOfResources = new PageImpl<>(resources.subList(start, end),
+    Page<ResourceDTO> pageOfResourceDTOs = new PageImpl<>(resources.subList(start, end),
         PageRequest.of(page, pageSize),
         numberOfResources);
 
-    when(resourceManagement.getAllResources(any()))
-        .thenReturn(pageOfResources);
+    when(resourceManagement.getAllResourceDTOs(any()))
+        .thenReturn(pageOfResourceDTOs);
 
     mockMvc.perform(get("/api/admin/resources")
         .contentType(MediaType.APPLICATION_JSON))
@@ -481,22 +485,22 @@ public class ResourceApiControllerTest {
         .andExpect(jsonPath("$.totalPages", equalTo(1)))
         .andExpect(jsonPath("$.totalElements", equalTo(numberOfResources)));
 
-    verify(resourceManagement).getAllResources(PageRequest.of(0, 20));
+    verify(resourceManagement).getAllResourceDTOs(PageRequest.of(0, 20));
     verifyNoMoreInteractions(resourceManagement);
   }
 
   @Test
   public void testGetStreamOfResources() throws Exception {
     int numberOfResources = 20;
-    List<Resource> resources = new ArrayList<>();
+    List<ResourceDTO> resources = new ArrayList<>();
     for (int i=0; i<numberOfResources; i++) {
-      resources.add(podamFactory.manufacturePojo(Resource.class));
+      resources.add(podamFactory.manufacturePojo(ResourceDTO.class));
     }
 
     List<String> expectedData = resources.stream()
         .map(r -> {
           try {
-            return "data:" + objectMapper.writeValueAsString(new ResourceDTO(r));
+            return "data:" + objectMapper.writeValueAsString(r);
           } catch (JsonProcessingException e) {
             assertThat(e, nullValue());
             return null;
@@ -504,7 +508,7 @@ public class ResourceApiControllerTest {
         }).collect(Collectors.toList());
     assertThat(expectedData.size(), equalTo(resources.size()));
 
-    Stream<Resource> resourceStream = resources.stream();
+    Stream<ResourceDTO> resourceStream = resources.stream();
 
     when(resourceManagement.getResources(true))
         .thenReturn(resourceStream);
@@ -522,11 +526,11 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetResourcesWithLabels() throws Exception {
 
-    final List<Resource> expectedResources = IntStream.range(0, 4)
-        .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
+    final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
+        .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any(), any(), any()))
+    when(resourceManagement.getResourceDTOsFromLabels(any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size()));
 
     mockMvc.perform(get(
@@ -535,7 +539,7 @@ public class ResourceApiControllerTest {
     ).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
 
-    verify(resourceManagement).getResourcesFromLabels(
+    verify(resourceManagement).getResourceDTOsFromLabels(
         Collections.singletonMap("env", "prod"),
         "t-1",
         LabelSelectorMethod.AND,
@@ -548,11 +552,11 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetResourcesWithLabels_largerPageSize() throws Exception {
 
-    final List<Resource> expectedResources = IntStream.range(0, 4)
-        .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
+    final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
+        .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any(), any(), any()))
+    when(resourceManagement.getResourceDTOsFromLabels(any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size()));
 
     mockMvc.perform(
@@ -567,7 +571,7 @@ public class ResourceApiControllerTest {
     )
         .andExpect(status().isOk());
 
-    verify(resourceManagement).getResourcesFromLabels(
+    verify(resourceManagement).getResourceDTOsFromLabels(
         Collections.singletonMap("env", "prod"),
         "t-1",
         LabelSelectorMethod.AND,
@@ -583,11 +587,11 @@ public class ResourceApiControllerTest {
     // grab the value that Spring Boot will configure
     final int maxPageSize = springDataWebProperties.getPageable().getMaxPageSize();
 
-    final List<Resource> expectedResources = IntStream.range(0, 4)
-        .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
+    final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
+        .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any(), any(), any()))
+    when(resourceManagement.getResourceDTOsFromLabels(any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(expectedResources, PageRequest.of(0, maxPageSize), expectedResources.size()));
 
     mockMvc.perform(
@@ -602,7 +606,7 @@ public class ResourceApiControllerTest {
     )
         .andExpect(status().isOk());
 
-    verify(resourceManagement).getResourcesFromLabels(
+    verify(resourceManagement).getResourceDTOsFromLabels(
         Collections.singletonMap("env", "prod"),
         "t-1",
         LabelSelectorMethod.AND,
@@ -616,11 +620,11 @@ public class ResourceApiControllerTest {
   @Test
   public void testGetAllTenantResourcesWithLabels() throws Exception {
 
-    final List<Resource> expectedResources = IntStream.range(0, 4)
-        .mapToObj(value -> podamFactory.manufacturePojo(Resource.class))
+    final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
+        .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))
         .collect(Collectors.toList());
 
-    when(resourceManagement.getResourcesFromLabels(any(), any(), any(), any()))
+    when(resourceManagement.getResourceDTOsFromLabels(any(), any(), any(), any()))
         .thenReturn(new PageImpl<>(expectedResources, Pageable.unpaged(), expectedResources.size()));
 
     mockMvc.perform(
@@ -633,7 +637,7 @@ public class ResourceApiControllerTest {
     )
         .andExpect(status().isOk());
 
-    verify(resourceManagement).getResourcesFromLabels(
+    verify(resourceManagement).getResourceDTOsFromLabels(
         Collections.singletonMap("env", "prod"),
         "t-1",
         LabelSelectorMethod.AND,

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -223,6 +223,7 @@ public class ResourceApiControllerTest {
         .setCreatedTimestamp(DEFAULT_TIMESTAMP.toString())
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP.toString())
         .setAssociatedWithEnvoy(false)
+        .setEnvoyId("e-1")
         .setId(1001L);
     when(resourceManagement.getResourceDTO(any(), any()))
         .thenReturn(expectedResource);

--- a/src/test/resources/ResourceApiControllerTest/single_public_resource_admin.json
+++ b/src/test/resources/ResourceApiControllerTest/single_public_resource_admin.json
@@ -8,5 +8,5 @@
   "associatedWithEnvoy":false,
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z",
-  "envoyId": null
+  "envoyId": "e-1"
 }

--- a/src/test/resources/ResourceApiControllerTest/single_public_resource_admin.json
+++ b/src/test/resources/ResourceApiControllerTest/single_public_resource_admin.json
@@ -7,5 +7,6 @@
   "presenceMonitoringEnabled":null,
   "associatedWithEnvoy":false,
   "createdTimestamp": "1970-01-02T03:46:40Z",
-  "updatedTimestamp": "1970-01-02T03:46:40Z"
+  "updatedTimestamp": "1970-01-02T03:46:40Z",
+  "envoyId": null
 }

--- a/src/test/resources/ResourceApiControllerTest/single_public_resource_customer.json
+++ b/src/test/resources/ResourceApiControllerTest/single_public_resource_customer.json
@@ -3,7 +3,6 @@
   "labels":{"env": "prod"},
   "metadata":{"custom": "new"},
   "presenceMonitoringEnabled":null,
-  "associatedWithEnvoy":false,
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }


### PR DESCRIPTION
# Resolves

SALUS-836

# What

Add the envoyId into the ResourceDTO response by grabbing it from etcd. It also adds access controls over the returned values so that we can control which types of users can see the values.

# How

We pull in the etcd-adapter library and use the connections there to interact with etcd and get the envoy information.

We can't remove the `associatedWithEnvoy` flag from the Resource Object until we add a full connection history. Without that we can't determine in ResourceManagement whether the envoy connection event was a reconnection or not. 

## How to test

The unit tests should be updated

# Why

I had briefly considered adding endpoints to the ambassador so that we could just ask it for the envoy information. But I was hesitant to add anything like that to a service that didn't have it yet and we already had the library to connect and pull information from etcd anyway.

# TODO

Open the Monitor Management PR
