### PR TITLE
Upgraded salus-telemetry-protocol for grpc 1.28.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.2-SNAPSHOT</version>
+      <version>0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

Aligning versions on latest salus-telemetry-protocol to pick up https://github.com/racker/salus-telemetry-protocol/pull/21 and then re-snapshot-ed at https://github.com/racker/salus-telemetry-protocol/commit/53589514f9d44b90661c097fead38c31232449d6