### PR TITLE
Ensure metadata is not stored as null

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/resource_management/services/ResourceManagement.java
@@ -35,6 +35,7 @@ import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -213,7 +214,8 @@ public class ResourceManagement {
         .setTenantId(tenantId)
         .setResourceId(newResource.getResourceId())
         .setLabels(newResource.getLabels())
-        .setMetadata(newResource.getMetadata())
+        .setMetadata(newResource.getMetadata() != null ?
+            newResource.getMetadata() : Collections.emptyMap())
         .setPresenceMonitoringEnabled(newResource.getPresenceMonitoringEnabled());
 
     resource = saveAndPublishResource(resource, true, null);
@@ -317,6 +319,7 @@ public class ResourceManagement {
           .setTenantId(tenantId)
           .setResourceId(resourceId)
           .setLabels(labels)
+          .setMetadata(Collections.emptyMap())
           .setPresenceMonitoringEnabled(true)
           .setAssociatedWithEnvoy(true);
       saveAndPublishResource(newResource, true, null);


### PR DESCRIPTION
# What

Store empty resource metadata as an empty map instead of null.

# How

Resources can be created in two places, via an api request or via an envoy attach.  Ensure each of those set an empty map if null is seen.

## How to test

Locally and the newly updated tests.

# Why

`NullPointerException` was being thrown when we try to get the `region` of a resource.

Since `metadata` is stored as `json` instead of an element collection, it would get stored/retrieved as null instead of an empty list (like what would happen with labels).
