### PR TITLE
Updated resource ID validation to allow dots for FQDNs

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/model/ResourceCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,14 @@ package com.rackspace.salus.resource_management.web.model;
 
 import java.io.Serializable;
 import java.util.Map;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-
 @Data
 public class ResourceCreate implements Serializable {
-    @Pattern(regexp="[A-Za-z0-9:-]+")
+    @Pattern(regexp="[A-Za-z0-9.:-]+")
     @NotBlank
     String resourceId;
 

--- a/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/controller/ResourceApiControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -337,7 +336,7 @@ public class ResourceApiControllerTest {
   @Test
   public void testCreateResource() throws Exception {
     ResourceDTO resource = podamFactory.manufacturePojo(ResourceDTO.class);
-    String resourceId = "resource28-13:databaseNode";
+    String resourceId = "resource28-13:databaseNode.com";
     resource.setResourceId(resourceId);
     when(resourceManagement.createResource(anyString(), any()))
         .thenReturn(resource);
@@ -410,7 +409,7 @@ public class ResourceApiControllerTest {
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andExpect(status().isBadRequest())
         .andExpect(validationError(
-            "resourceId", "must match \"[A-Za-z0-9:-]+\""
+            "resourceId", "must match \"[A-Za-z0-9.:-]+\""
         ));
 
     verifyNoMoreInteractions(resourceManagement);


### PR DESCRIPTION
# What

Following on from https://github.com/racker/salus-telemetry-resource-management/pull/71 this allows for dots/periods to be used in resource IDs. The existing validation became to restrictive for our own monitoring where we are using FQDNs for the resource ID.

# How to test

Unit tests update