### PR TITLE
Removed getByResourceId from ResourceApiClient

### DIFF
--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ public interface ResourceApi {
   List<ResourceDTO> getResourcesWithLabels(String tenantId,
                                         Map<String, String> labels,
                                         LabelSelectorMethod labelSelector);
-
-  List<ResourceDTO> getExpectedEnvoys();
 
   List<String> getAllDistinctTenantIds();
 

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApi.java
@@ -31,9 +31,6 @@ import org.springframework.util.MultiValueMap;
  */
 public interface ResourceApi {
 
-  ResourceDTO getByResourceId(String tenantId,
-                           String resourceId);
-
   List<ResourceDTO> getResourcesWithLabels(String tenantId,
                                         Map<String, String> labels,
                                         LabelSelectorMethod labelSelector);

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -89,24 +89,6 @@ public class ResourceApiClient implements ResourceApi {
   }
 
   @Override
-  public ResourceDTO getByResourceId(String tenantId, String resourceId) {
-    try {
-      return restTemplate.getForObject(
-          "/api/tenant/{tenantId}/resources/{resourceId}",
-          ResourceDTO.class,
-          tenantId, resourceId
-      );
-    } catch (HttpClientErrorException e) {
-      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-        return null;
-      }
-      else {
-        throw new IllegalArgumentException(e);
-      }
-    }
-  }
-
-  @Override
   public List<ResourceDTO> getResourcesWithLabels(String tenantId, Map<String, String> labels,
                                                   LabelSelectorMethod labelSelector) {
     String endpoint = "/api/admin/resources-by-label/{tenantId}/{logicalOperator}";

--- a/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
+++ b/src/main/java/com/rackspace/salus/resource_management/web/client/ResourceApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,30 +106,6 @@ public class ResourceApiClient implements ResourceApi {
     );
 
     return Objects.requireNonNull(resp.getBody());
-  }
-
-  @Override
-  public List<ResourceDTO> getExpectedEnvoys() {
-    String endpoint = "/api/envoys";
-    List<ResourceDTO> resources = new ArrayList<>();
-
-    restTemplate.execute(endpoint, HttpMethod.GET, request -> {}, response -> {
-      BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));
-      String line;
-      while ((line = bufferedReader.readLine()) != null) {
-        if (line.length() > SSEHdr.length())
-          try {
-            ResourceDTO resource;
-            // remove the "data:" hdr
-            resource = objectMapper.readValue(line.substring(SSEHdr.length()), ResourceDTO.class);
-            resources.add(resource);
-          } catch (IOException e) {
-            log.warn("Failed to parse Resource", e);
-          }
-      }
-      return response;
-    });
-    return resources;
   }
 
   @Override

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -76,30 +76,6 @@ public class ResourceApiClientTest {
   private static final String SSEHdr = "data:";
 
   @Test
-  public void getByResourceId() throws JsonProcessingException {
-
-    ResourceDTO expectedResource = podamFactory.manufacturePojo(ResourceDTO.class);
-    mockServer.expect(requestTo("/api/tenant/t-1/resources/r-1"))
-        .andRespond(withSuccess(
-            objectMapper.writeValueAsString(expectedResource), MediaType.APPLICATION_JSON
-        ));
-
-    final ResourceDTO resource = resourceApiClient.getByResourceId("t-1", "r-1");
-
-    assertThat(resource, equalTo(expectedResource));
-  }
-
-  @Test
-  public void testGetByResourceId_notFound() {
-    mockServer.expect(requestTo("/api/tenant/t-1/resources/r-not-here"))
-        .andRespond(withStatus(HttpStatus.NOT_FOUND));
-
-    final ResourceDTO resource = resourceApiClient.getByResourceId("t-1", "r-not-here");
-
-    assertThat(resource, nullValue());
-  }
-
-  @Test
   public void testGetResourcesWithLabels() throws JsonProcessingException {
     final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
         .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))

--- a/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/resource_management/web/client/ResourceApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,27 +89,6 @@ public class ResourceApiClientTest {
     final List<ResourceDTO> resources = resourceApiClient
         .getResourcesWithLabels("t-1", Collections.singletonMap("env", "prod"), LabelSelectorMethod.AND);
 
-    assertThat(resources, equalTo(expectedResources));
-  }
-
-  @Test
-  public void testGetExpectedEnvoys() throws JsonProcessingException {
-    final List<ResourceDTO> expectedResources = IntStream.range(0, 4)
-            .mapToObj(value -> podamFactory.manufacturePojo(ResourceDTO.class))
-            .collect(Collectors.toList());
-
-    StringBuilder responseStream = new StringBuilder();
-    for (ResourceDTO r : expectedResources) {
-      String line = String.format("%s%s\n", SSEHdr, objectMapper.writeValueAsString(r));
-      responseStream.append(line);
-    }
-
-    mockServer.expect(requestTo("/api/envoys"))
-            .andRespond(withSuccess(responseStream.toString(), MediaType.TEXT_EVENT_STREAM));
-
-    final List<ResourceDTO> resources = resourceApiClient.getExpectedEnvoys();
-
-    assertThat(resources.size(), equalTo(expectedResources.size()));
     assertThat(resources, equalTo(expectedResources));
   }
 


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-1014

# What
Removed getByResourceId from ResourceApiClient

## How to test
This can be tested by unit test cases

# Why
No need for get resource id method as it can be used as DB retrieval call
